### PR TITLE
Remove environments dependency from railroad benchmarks

### DIFF
--- a/packages/environments/src/environments/__init__.py
+++ b/packages/environments/src/environments/__init__.py
@@ -5,4 +5,3 @@ robot simulation and PDDL planning execution.
 """
 
 from . import procthor, plotting, utils, pyrobosim
-from .environments import SimpleEnvironment

--- a/packages/environments/src/environments/benchmarks/heterogeneous_robots.py
+++ b/packages/environments/src/environments/benchmarks/heterogeneous_robots.py
@@ -8,8 +8,7 @@ import numpy as np
 from railroad.core import Fluent as F, State, get_action_by_name
 from railroad.planner import MCTSPlanner
 from railroad.dashboard import PlannerDashboard
-from railroad.environment import EnvironmentInterface
-from environments import SimpleEnvironment
+from railroad.environment import EnvironmentInterface, SimpleEnvironment
 from railroad import operators
 from railroad._bindings import ff_heuristic
 from rich.console import Console

--- a/packages/environments/src/environments/environments.py
+++ b/packages/environments/src/environments/environments.py
@@ -1,9 +1,0 @@
-"""Environment implementations for robot simulation.
-
-SimpleEnvironment has been moved to railroad.environment.
-This module re-exports it for backward compatibility.
-"""
-
-from railroad.environment import SimpleEnvironment
-
-__all__ = ["SimpleEnvironment"]

--- a/packages/environments/tests/test_simulator_actions.py
+++ b/packages/environments/tests/test_simulator_actions.py
@@ -2,8 +2,7 @@ import numpy as np
 from railroad.core import Fluent as F, State, get_action_by_name, LiteralGoal
 from railroad.planner import MCTSPlanner
 from railroad import operators
-from environments import SimpleEnvironment
-from railroad.environment import EnvironmentInterface
+from railroad.environment import EnvironmentInterface, SimpleEnvironment
 
 
 LOCATIONS = {

--- a/packages/environments/tests/test_simulator_advance_method.py
+++ b/packages/environments/tests/test_simulator_advance_method.py
@@ -2,8 +2,7 @@ import pytest
 import numpy as np
 from railroad.core import Fluent as F, State, get_action_by_name
 from railroad import operators
-from railroad.environment import EnvironmentInterface
-from environments import SimpleEnvironment
+from railroad.environment import EnvironmentInterface, SimpleEnvironment
 
 # Fancy error handling; shows local vars
 from rich.traceback import install

--- a/packages/railroad/src/railroad/bench/benchmarks/basic_planning.py
+++ b/packages/railroad/src/railroad/bench/benchmarks/basic_planning.py
@@ -7,8 +7,7 @@ Demonstrates benchmark registration and parametrization.
 from railroad.bench import benchmark, BenchmarkCase
 from railroad.core import Fluent as F, State, get_action_by_name
 from railroad.planner import MCTSPlanner
-from environments import SimpleEnvironment
-from railroad.environment import EnvironmentInterface
+from railroad.environment import EnvironmentInterface, SimpleEnvironment
 from railroad import operators
 import time
 

--- a/packages/railroad/src/railroad/bench/benchmarks/movie_night.py
+++ b/packages/railroad/src/railroad/bench/benchmarks/movie_night.py
@@ -19,9 +19,7 @@ import numpy as np
 from railroad.core import Fluent as F, State, get_action_by_name
 from railroad.planner import MCTSPlanner
 from railroad.dashboard import PlannerDashboard
-import environments
-from railroad.environment import EnvironmentInterface as Simulator
-from environments import SimpleEnvironment
+from railroad.environment import EnvironmentInterface as Simulator, SimpleEnvironment
 from railroad import operators
 from railroad.core import ff_heuristic
 from rich.console import Console

--- a/scripts/test-standalone-install.sh
+++ b/scripts/test-standalone-install.sh
@@ -63,4 +63,8 @@ log_info "Running tests..."
 log_info "Running example to verify dependencies..."
 .venv/bin/railroad example clear-table
 
+# Test benchmarks discovery (dry-run to avoid running actual benchmarks)
+log_info "Testing benchmark discovery..."
+.venv/bin/railroad benchmarks run --dry-run
+
 log_info "Standalone install test completed successfully!"


### PR DESCRIPTION
Railroad benchmarks now import SimpleEnvironment from railroad.environment instead of the external environments package, allowing them to run in standalone installations. They should have been migrated already, but a bit of the repo had kept around some of the old API. Changes:

- Update basic_planning.py and movie_night.py to use railroad.environment
- Remove backwards-compatibility re-export from environments package
- Update environments tests and benchmarks to use railroad.environment
- Add benchmark discovery test to standalone install script

Quick fix for a bug that `uv run railroad benchmarks` would fail when only `railroad` was installed.