### PR TITLE
Add ProcTHOR-search benchmark and experiment compaction cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ data/
 mlruns
 mlflow.db
 .worktrees/
+.benchmark_cache/

--- a/packages/railroad/src/railroad/bench/analysis.py
+++ b/packages/railroad/src/railroad/bench/analysis.py
@@ -38,6 +38,13 @@ class BenchmarkAnalyzer:
         """
         experiments = mlflow.search_experiments()  # type: ignore[possibly-missing-attribute]
 
+        def _is_railroad_exp(exp) -> bool:
+            tags = exp.tags or {}
+            if tags.get("railroad_bench") == "1":
+                return True
+            # Backward compatibility: legacy experiments lacked the marker tag
+            return exp.name.startswith("railroad_bench_")
+
         df = pd.DataFrame([
             {
                 "name": exp.name,
@@ -46,7 +53,7 @@ class BenchmarkAnalyzer:
                 "tags": exp.tags if exp.tags else {},
             }
             for exp in experiments
-            if exp.name.startswith("railroad_bench_")
+            if _is_railroad_exp(exp)
         ])
 
         if not df.empty:
@@ -84,12 +91,17 @@ class BenchmarkAnalyzer:
 
         return metadata
 
-    def get_experiment_summary(self, experiment_name: str) -> dict:
+    def get_experiment_summary(
+        self,
+        experiment_name: str,
+        df: Optional[pd.DataFrame] = None,
+    ) -> dict:
         """
         Get summary statistics for an experiment.
 
         Args:
             experiment_name: Name of the experiment
+            df: Optional pre-loaded runs DataFrame to avoid a redundant load
 
         Returns:
             Dictionary with summary statistics including:
@@ -102,7 +114,8 @@ class BenchmarkAnalyzer:
         Raises:
             ValueError: If experiment not found
         """
-        df = self.load_experiment(experiment_name)
+        if df is None:
+            df = self.load_experiment(experiment_name)
 
         summary = {
             "total_runs": len(df),

--- a/packages/railroad/src/railroad/bench/benchmarks/__init__.py
+++ b/packages/railroad/src/railroad/bench/benchmarks/__init__.py
@@ -9,9 +9,11 @@ Benchmarks are automatically registered when decorated.
 from . import basic_planning
 from . import movie_night
 from . import multi_object_search
+from . import procthor_search
 
 __all__ = [
     "basic_planning",
     "movie_night",
     "multi_object_search",
+    "procthor_search",
 ]

--- a/packages/railroad/src/railroad/bench/benchmarks/procthor_search.py
+++ b/packages/railroad/src/railroad/bench/benchmarks/procthor_search.py
@@ -146,16 +146,27 @@ def bench_procthor_search(case: BenchmarkCase):
     dashboard.print_history()
     html_output = recording_console.export_html(inline_styles=True)
 
-    return {
+    result = {
         "success": goal.evaluate(env.state.fluents),
         "wall_time": time.perf_counter() - start_time,
         "plan_cost": float(env.state.time),
         "actions_count": len(actions_taken),
         "actions": actions_taken,
-        "target_location": target_location,
-        "target_objects": target_objects,
         "log_html": html_output,
     }
+
+    try:
+        location_coords = {
+            name: (float(coord[0]), float(coord[1]))
+            for name, coord in env.scene.locations.items()
+        }
+        plot_image = dashboard.get_plot_image(location_coords=location_coords)
+        if plot_image is not None:
+            result["log_plot"] = plot_image
+    except Exception as e:
+        print(f"Failed to render trajectory plot: {e}")
+
+    return result
 
 
 bench_procthor_search.add_cases([
@@ -173,6 +184,6 @@ bench_procthor_search.add_cases([
         [2, 4, 10],          # mcts.h_mult
         [4000, 10000],       # mcts.iterations
         [2],                 # num_objects
-        list(8610, 8620),    # scene_seed
+        list(range(8610, 8620)),  # scene_seed
     )
 ])

--- a/packages/railroad/src/railroad/bench/benchmarks/procthor_search.py
+++ b/packages/railroad/src/railroad/bench/benchmarks/procthor_search.py
@@ -178,12 +178,12 @@ bench_procthor_search.add_cases([
         "num_objects": num_objects,
         "scene_seed": scene_seed,
     }
-    for c, num_robots, h_mult, iterations, num_objects, scene_seed in itertools.product(
+    for scene_seed, c, num_robots, h_mult, iterations, num_objects in itertools.product(
+        list(range(8610, 8620)),  # scene_seed
         [400],               # mcts.c
         [1, 2, 3],           # num_robots
         [2, 4, 10],          # mcts.h_mult
         [4000, 10000],       # mcts.iterations
         [2],                 # num_objects
-        list(range(8610, 8620)),  # scene_seed
     )
 ])

--- a/packages/railroad/src/railroad/bench/benchmarks/procthor_search.py
+++ b/packages/railroad/src/railroad/bench/benchmarks/procthor_search.py
@@ -1,0 +1,178 @@
+"""
+ProcTHOR Multi-Robot Search Benchmark
+
+Wraps the procthor_search example as a benchmark case. Robots must search
+a ProcTHOR-generated household scene to find target objects and bring them
+to a designated room.
+
+Modeled on movie_night.py for benchmark plumbing and on
+railroad.examples.procthor_search for the environment / operator setup.
+"""
+
+import time
+import itertools
+import random
+from functools import reduce
+from operator import and_
+
+from rich.console import Console
+
+from railroad.core import Fluent as F, Operator, State, get_action_by_name
+from railroad.planner import MCTSPlanner
+from railroad.dashboard import PlannerDashboard
+from railroad import operators
+from railroad.bench import benchmark, BenchmarkCase
+
+
+def _sample_objects_and_location(scene, num_objects: int, seed: int | None):
+    rng = random.Random(seed)
+    all_objects = sorted({
+        obj
+        for objs in scene.object_locations.values()
+        for obj in objs
+    })
+    all_locations = sorted(scene.object_locations.keys())
+    return (
+        rng.sample(all_objects, k=min(num_objects, len(all_objects))),
+        rng.choice(all_locations),
+    )
+
+
+@benchmark(
+    name="procthor_search",
+    description="Multi-robot search in a ProcTHOR-generated household scene.",
+    tags=["multi-agent", "search", "procthor"],
+    timeout=600.0,
+    repeat=15,
+)
+def bench_procthor_search(case: BenchmarkCase):
+    from railroad.environment.procthor import ProcTHOREnvironment
+
+    num_robots = case.params["num_robots"]
+    num_objects = case.params["num_objects"]
+    scene_seed = case.params["scene_seed"]
+    sample_seed = case.params.get("sample_seed", scene_seed)
+
+    class SearchProcTHOREnvironment(ProcTHOREnvironment):
+        """Bench-local ProcTHOR env with internal operator construction."""
+
+        def set_target_objects(self, target_objects: list[str]) -> None:
+            self._target_objects_for_search = list(target_objects)
+            self.objects_by_type["object"] = set(target_objects)
+            self._operators = self.define_operators()
+
+        def define_operators(self) -> list[Operator]:
+            def object_find_prob_fn(robot: str, location: str, obj: str) -> float:
+                del robot
+                for loc, objs in self.scene.object_locations.items():
+                    if obj in objs:
+                        return 0.8 if loc == location else 0.1
+                return 0.1
+
+            move_op = operators.construct_move_operator_blocking(self.estimate_move_time)
+            search_op = operators.construct_search_operator(object_find_prob_fn, 10.0)
+            pick_op = operators.construct_pick_operator_blocking(10.0)
+            place_op = operators.construct_place_operator_blocking(10.0)
+            no_op = operators.construct_no_op_operator(no_op_time=5.0, extra_cost=100.0)
+            return [no_op, pick_op, place_op, move_op, search_op]
+
+    robot_names = [f"robot{i + 1}" for i in range(num_robots)]
+
+    initial_fluents = {F("revealed start_loc")}
+    for robot in robot_names:
+        initial_fluents.add(F(f"at {robot} start_loc"))
+        initial_fluents.add(F(f"free {robot}"))
+    initial_state = State(0.0, initial_fluents, [])
+
+    env = SearchProcTHOREnvironment(
+        seed=scene_seed,
+        state=initial_state,
+        objects_by_type={
+            "robot": set(robot_names),
+            "location": {"start_loc"},
+        },
+    )
+    env.objects_by_type["location"] = set(env.scene.locations.keys())
+
+    target_objects, target_location = _sample_objects_and_location(
+        env.scene,
+        num_objects=num_objects,
+        seed=sample_seed,
+    )
+    env.set_target_objects(target_objects)
+
+    goal = reduce(and_, [
+        F(f"at {obj} {target_location}") & F(f"found {obj}")
+        for obj in target_objects
+    ])
+
+    max_iterations = 60
+
+    recording_console = Console(record=True, force_terminal=True, width=120)
+
+    def fluent_filter(f):
+        return any(kw in f.name for kw in ["at", "holding", "found", "searched"])
+
+    dashboard = PlannerDashboard(
+        goal, env, fluent_filter=fluent_filter,
+        print_on_exit=False, console=recording_console,
+    )
+
+    start_time = time.perf_counter()
+
+    for _iteration in range(max_iterations):
+        if goal.evaluate(env.state.fluents):
+            break
+
+        all_actions = env.get_actions()
+        mcts = MCTSPlanner(all_actions)
+        action_name = mcts(
+            env.state, goal,
+            max_iterations=case.mcts.iterations,
+            c=case.mcts.c,
+            max_depth=20,
+            heuristic_multiplier=case.mcts.h_mult,
+        )
+
+        if action_name == "NONE":
+            dashboard.console.print("No more actions available. Goal may not be achievable.")
+            break
+
+        action = get_action_by_name(all_actions, action_name)
+        env.act(action)
+        dashboard.update(mcts, action_name)
+
+    actions_taken = [name for name, _ in dashboard.actions_taken]
+    dashboard.print_history()
+    html_output = recording_console.export_html(inline_styles=True)
+
+    return {
+        "success": goal.evaluate(env.state.fluents),
+        "wall_time": time.perf_counter() - start_time,
+        "plan_cost": float(env.state.time),
+        "actions_count": len(actions_taken),
+        "actions": actions_taken,
+        "target_location": target_location,
+        "target_objects": target_objects,
+        "log_html": html_output,
+    }
+
+
+bench_procthor_search.add_cases([
+    {
+        "mcts.iterations": iterations,
+        "mcts.c": c,
+        "mcts.h_mult": h_mult,
+        "num_robots": num_robots,
+        "num_objects": num_objects,
+        "scene_seed": scene_seed,
+    }
+    for c, num_robots, h_mult, iterations, num_objects, scene_seed in itertools.product(
+        [400],               # mcts.c
+        [1, 2, 3],           # num_robots
+        [2, 4, 10],          # mcts.h_mult
+        [4000, 10000],       # mcts.iterations
+        [2],                 # num_objects
+        list(8610, 8620),    # scene_seed
+    )
+])

--- a/packages/railroad/src/railroad/bench/compact.py
+++ b/packages/railroad/src/railroad/bench/compact.py
@@ -1,0 +1,280 @@
+"""
+Lazy compaction cache for benchmark experiments.
+
+MLflow stores each run in many small files / SQLite rows, which makes loading
+a finished experiment slow. To speed up dashboard browsing, we materialize a
+single Parquet (runs) + JSON (metadata + summary) cache per experiment in
+``.benchmark_cache/<exp_name>/``.
+
+The cache is a *staleness-checked* projection of the source data. We use the
+mtime of the SQLite backend file plus the experiment's artifact directory as
+a fingerprint: if either has been modified since the cache was written, we
+treat the cache as stale and recompute. We also refuse to write a cache while
+any run is still ``RUNNING``/``SCHEDULED`` — that way an in-progress run
+never produces a cache that gets stuck.
+
+Killing a run mid-way is fine: MLflow flips its status to ``FAILED`` /
+``KILLED``, the run is no longer ``RUNNING``, and the experiment becomes
+eligible for compaction on the next load.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import dataclasses
+
+import mlflow
+import pandas as pd
+import plotly.io as pio
+from plotly.graph_objects import Figure
+
+
+CACHE_DIR_NAME = ".benchmark_cache"
+
+
+def _cache_dir() -> Path:
+    return Path(CACHE_DIR_NAME)
+
+
+def _cache_paths(exp_name: str) -> tuple[Path, Path, Path]:
+    d = _cache_dir() / exp_name
+    return d / "runs.parquet", d / "meta.json", d / "figures.json"
+
+
+def _serialize_figures(figures: dict) -> dict:
+    """Serialize plotly Figures to JSON-safe dicts in-place-equivalent.
+
+    Expects the shape produced by ``create_violin_plots_by_benchmark`` and
+    ``create_all_sweep_plots``: violins are ``[{"benchmark": str, "figure": Figure}]``,
+    sweeps are ``{benchmark: [{"title": str, "figure": Figure, ...}]}``.
+    """
+    def _encode(value):
+        if isinstance(value, Figure):
+            return {"__plotly__": True, "json": pio.to_json(value)}
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            # Avoid dataclasses.asdict because it recursively converts nested
+            # dataclasses to plain dicts before our encoder sees them.
+            return {
+                "__dataclass__": type(value).__name__,
+                "fields": {
+                    f.name: _encode(getattr(value, f.name))
+                    for f in dataclasses.fields(value)
+                },
+            }
+        if isinstance(value, dict):
+            return {k: _encode(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_encode(v) for v in value]
+        return value
+
+    def _encode_item(item):
+        return {k: _encode(v) for k, v in item.items()}
+
+    out = {}
+    if "violin" in figures:
+        out["violin"] = [_encode_item(item) for item in figures["violin"]]
+    if "sweep" in figures:
+        out["sweep"] = {
+            bench: [_encode_item(item) for item in sweep_list]
+            for bench, sweep_list in figures["sweep"].items()
+        }
+    return out
+
+
+# Registry of dataclasses we know how to round-trip. Imports are deferred to
+# avoid circular imports during module load.
+def _dataclass_registry() -> dict:
+    from railroad.bench.dashboard.sweeps import SweepAnalysis, SweepGroup
+    return {
+        "SweepAnalysis": SweepAnalysis,
+        "SweepGroup": SweepGroup,
+    }
+
+
+def _deserialize_figures(payload: dict) -> dict:
+    registry = _dataclass_registry()
+
+    def _decode(value):
+        if isinstance(value, dict):
+            if value.get("__plotly__"):
+                return pio.from_json(value["json"])
+            if "__dataclass__" in value:
+                cls = registry.get(value["__dataclass__"])
+                if cls is None:
+                    return {k: _decode(v) for k, v in value["fields"].items()}
+                return cls(**{k: _decode(v) for k, v in value["fields"].items()})
+            return {k: _decode(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_decode(v) for v in value]
+        return value
+
+    def _decode_item(item):
+        return {k: _decode(v) for k, v in item.items()}
+
+    out = {}
+    if "violin" in payload:
+        out["violin"] = [_decode_item(item) for item in payload["violin"]]
+    if "sweep" in payload:
+        out["sweep"] = {
+            bench: [_decode_item(item) for item in sweep_list]
+            for bench, sweep_list in payload["sweep"].items()
+        }
+    return out
+
+
+def _artifact_root(exp_name: str) -> Optional[Path]:
+    """Return the experiment's artifact directory (best-effort)."""
+    try:
+        exp = mlflow.get_experiment_by_name(exp_name)  # type: ignore[possibly-missing-attribute]
+    except Exception:
+        return None
+    if exp is None or not exp.artifact_location:
+        return None
+    loc = exp.artifact_location
+    # Strip common URI prefixes
+    if loc.startswith("file://"):
+        loc = loc[len("file://"):]
+    if loc.startswith("mlflow-artifacts:"):
+        # Cannot resolve to a filesystem path without server context
+        return None
+    p = Path(loc)
+    return p if p.exists() else None
+
+
+def _source_fingerprint(exp_name: str) -> dict:
+    """A cheap stamp that changes whenever the experiment data changes."""
+    fp: dict = {}
+    db = Path("mlflow.db")
+    if db.exists():
+        fp["db_mtime"] = db.stat().st_mtime
+    art = _artifact_root(exp_name)
+    if art is not None:
+        try:
+            mtimes = [f.stat().st_mtime for f in art.rglob("*") if f.is_file()]
+            fp["artifact_mtime"] = max(mtimes) if mtimes else 0.0
+        except Exception:
+            pass
+    return fp
+
+
+def _has_in_progress_runs(df: pd.DataFrame) -> bool:
+    if df.empty or "status" not in df.columns:
+        return False
+    return df["status"].isin(["RUNNING", "SCHEDULED"]).any()
+
+
+def load(exp_name: str) -> Optional[tuple[pd.DataFrame, dict, dict]]:
+    """
+    Return ``(df, metadata, summary)`` if a fresh cache exists, else ``None``.
+    """
+    runs_path, meta_path, _figures_path = _cache_paths(exp_name)
+    if not runs_path.exists() or not meta_path.exists():
+        return None
+    try:
+        with open(meta_path) as f:
+            cached = json.load(f)
+        if cached.get("fingerprint") != _source_fingerprint(exp_name):
+            return None
+        df = pd.read_parquet(runs_path)
+        return df, cached["metadata"], cached["summary"]
+    except Exception:
+        return None
+
+
+def load_figures(exp_name: str) -> Optional[dict]:
+    """
+    Return cached figures (deserialized) if a fresh cache exists, else ``None``.
+
+    Validates the figures cache against its own embedded fingerprint so that
+    figures stay correctly invalidated even when the runs/meta cache cannot be
+    refreshed (e.g., while runs are still in progress).
+    """
+    _runs_path, _meta_path, figures_path = _cache_paths(exp_name)
+    if not figures_path.exists():
+        return None
+    try:
+        with open(figures_path) as f:
+            payload = json.load(f)
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("fingerprint") != _source_fingerprint(exp_name):
+            return None
+        return _deserialize_figures(payload.get("figures", {}))
+    except Exception:
+        return None
+
+
+def save(
+    exp_name: str,
+    df: pd.DataFrame,
+    metadata: dict,
+    summary: dict,
+    figures: Optional[dict] = None,
+) -> bool:
+    """
+    Persist the cache for ``exp_name``. Returns True if written.
+
+    Skips writing while any run is still in progress. If ``figures`` is
+    provided, it is serialized to ``figures.json``.
+    """
+    if _has_in_progress_runs(df):
+        return False
+    runs_path, meta_path, figures_path = _cache_paths(exp_name)
+    runs_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(runs_path, index=False)
+    payload = {
+        "metadata": metadata,
+        "summary": summary,
+        "fingerprint": _source_fingerprint(exp_name),
+        "cached_at": datetime.now().isoformat(),
+    }
+    with open(meta_path, "w") as f:
+        json.dump(payload, f, default=str)
+    if figures is not None:
+        _write_figures(figures_path, figures)
+    return True
+
+
+def _write_figures(figures_path: Path, figures: dict) -> None:
+    figures_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        # Embed an independent fingerprint so figures stay correctly
+        # invalidated even when runs/meta can't be refreshed.
+        "fingerprint": _source_fingerprint(figures_path.parent.name),
+        "cached_at": datetime.now().isoformat(),
+        "figures": _serialize_figures(figures),
+    }
+    with open(figures_path, "w") as f:
+        json.dump(payload, f)
+
+
+def save_figures(exp_name: str, figures: dict) -> bool:
+    """
+    Persist the figures cache for ``exp_name``.
+
+    Independent of the runs/meta cache: writes against the *current* source
+    fingerprint, so the saved figures will be invalidated as soon as the
+    underlying experiment data changes.
+    """
+    _runs_path, _meta_path, figures_path = _cache_paths(exp_name)
+    _write_figures(figures_path, figures)
+    return True
+
+
+def invalidate(exp_name: str) -> None:
+    """Remove the cache directory for ``exp_name`` if present."""
+    d = _cache_dir() / exp_name
+    if d.exists():
+        shutil.rmtree(d)
+
+
+def invalidate_all() -> None:
+    """Remove the entire cache directory."""
+    d = _cache_dir()
+    if d.exists():
+        shutil.rmtree(d)

--- a/packages/railroad/src/railroad/bench/compact.py
+++ b/packages/railroad/src/railroad/bench/compact.py
@@ -154,18 +154,25 @@ def _source_fingerprint(exp_name: str) -> dict:
         fp["db_mtime"] = db.stat().st_mtime
     art = _artifact_root(exp_name)
     if art is not None:
+        # Use the directory's own mtime rather than walking the tree: artifact
+        # writes update the containing run dir's mtime, and that's enough to
+        # detect new/changed runs without an O(n) scan on every load.
         try:
-            mtimes = [f.stat().st_mtime for f in art.rglob("*") if f.is_file()]
+            run_dirs = [p for p in art.iterdir() if p.is_dir()]
+            mtimes = [art.stat().st_mtime] + [d.stat().st_mtime for d in run_dirs]
             fp["artifact_mtime"] = max(mtimes) if mtimes else 0.0
         except Exception:
             pass
     return fp
 
 
+_TERMINAL_STATUSES = {"FINISHED", "FAILED", "KILLED"}
+
+
 def _has_in_progress_runs(df: pd.DataFrame) -> bool:
     if df.empty or "status" not in df.columns:
         return False
-    return df["status"].isin(["RUNNING", "SCHEDULED"]).any()
+    return (~df["status"].isin(_TERMINAL_STATUSES)).any()
 
 
 def load(exp_name: str) -> Optional[tuple[pd.DataFrame, dict, dict]]:
@@ -236,16 +243,16 @@ def save(
     with open(meta_path, "w") as f:
         json.dump(payload, f, default=str)
     if figures is not None:
-        _write_figures(figures_path, figures)
+        _write_figures(exp_name, figures_path, figures)
     return True
 
 
-def _write_figures(figures_path: Path, figures: dict) -> None:
+def _write_figures(exp_name: str, figures_path: Path, figures: dict) -> None:
     figures_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         # Embed an independent fingerprint so figures stay correctly
         # invalidated even when runs/meta can't be refreshed.
-        "fingerprint": _source_fingerprint(figures_path.parent.name),
+        "fingerprint": _source_fingerprint(exp_name),
         "cached_at": datetime.now().isoformat(),
         "figures": _serialize_figures(figures),
     }
@@ -262,7 +269,7 @@ def save_figures(exp_name: str, figures: dict) -> bool:
     underlying experiment data changes.
     """
     _runs_path, _meta_path, figures_path = _cache_paths(exp_name)
-    _write_figures(figures_path, figures)
+    _write_figures(exp_name, figures_path, figures)
     return True
 
 

--- a/packages/railroad/src/railroad/bench/dashboard/callbacks.py
+++ b/packages/railroad/src/railroad/bench/dashboard/callbacks.py
@@ -8,10 +8,11 @@ from dash import Output, Input, State, ALL, callback_context, html
 from flask import send_file
 import mlflow
 
-from railroad.bench.analysis import BenchmarkAnalyzer
+from railroad.bench import compact
 from .data import (
     load_all_experiments_with_summaries,
     load_experiment_by_name,
+    load_experiment_summary,
     _artifact_cache,
 )
 from .figures import create_violin_plots_by_benchmark
@@ -92,14 +93,28 @@ def register_callbacks(app):
                 try:
                     df, experiment_name, metadata = load_experiment_by_name(experiment_name)
 
-                    # Get experiment summary
-                    analyzer = BenchmarkAnalyzer()
-                    summary = analyzer.get_experiment_summary(experiment_name)
+                    # Summary comes from the compaction cache when fresh; otherwise
+                    # it's computed from the already-loaded df.
+                    summary = load_experiment_summary(experiment_name, df=df)
 
-                    figures = create_violin_plots_by_benchmark(df)
-
-                    # Generate sweep plots
-                    sweep_plots_by_benchmark = create_all_sweep_plots(df)
+                    # Figures cache: avoids re-running plot generation on every
+                    # page load when nothing about the experiment has changed.
+                    cached_figs = compact.load_figures(experiment_name)
+                    if cached_figs is not None:
+                        figures = cached_figs.get("violin", [])
+                        sweep_plots_by_benchmark = cached_figs.get("sweep", {})
+                        print(f"Loaded figures for '{experiment_name}' from cache")
+                    else:
+                        figures = create_violin_plots_by_benchmark(df)
+                        sweep_plots_by_benchmark = create_all_sweep_plots(df)
+                        try:
+                            if compact.save_figures(
+                                experiment_name,
+                                {"violin": figures, "sweep": sweep_plots_by_benchmark},
+                            ):
+                                print(f"Cached figures for '{experiment_name}'")
+                        except Exception as e:
+                            print(f"  ✗ Failed to cache figures: {e}")
 
                     content = build_content_layout(
                         experiment_name, figures, df, metadata, summary,

--- a/packages/railroad/src/railroad/bench/dashboard/data.py
+++ b/packages/railroad/src/railroad/bench/dashboard/data.py
@@ -4,35 +4,81 @@ Data loading functions for MLflow experiments.
 
 import pandas as pd
 from railroad.bench.analysis import BenchmarkAnalyzer
+from railroad.bench import compact
 
 
 # Global cache for downloaded artifact paths
 _artifact_cache: dict[str, str] = {}
 
 
-def load_experiment_by_name(experiment_name: str) -> tuple[pd.DataFrame, str, dict]:
+def load_experiment_by_name(
+    experiment_name: str,
+    use_cache: bool = True,
+) -> tuple[pd.DataFrame, str, dict]:
     """
     Load a specific experiment by name.
+
+    Args:
+        experiment_name: Name of the experiment
+        use_cache: If True, consult the compaction cache first and refresh it
 
     Returns:
         Tuple of (dataframe, experiment_name, metadata)
     """
+    if use_cache:
+        cached = compact.load(experiment_name)
+        if cached is not None:
+            df, metadata, _summary = cached
+            print(f"Loaded experiment '{experiment_name}' from cache ({len(df)} runs)")
+            return df, experiment_name, metadata
+
+    print(f"Loading experiment: {experiment_name}")
     analyzer = BenchmarkAnalyzer()
     df = analyzer.load_experiment(experiment_name)
     metadata = analyzer.get_experiment_metadata(experiment_name)
-
-    print(f"Loading experiment: {experiment_name}")
     print(f"Loaded {len(df)} runs")
+
+    if use_cache:
+        try:
+            summary = analyzer.get_experiment_summary(experiment_name, df=df)
+            if compact.save(experiment_name, df, metadata, summary):
+                print(f"Cached experiment '{experiment_name}'")
+        except Exception as e:
+            print(f"  ✗ Failed to cache: {e}")
 
     return df, experiment_name, metadata
 
 
-def load_all_experiments_with_summaries(limit: int = 10) -> list[dict]:
+def load_experiment_summary(
+    experiment_name: str,
+    df: pd.DataFrame | None = None,
+    use_cache: bool = True,
+) -> dict:
+    """
+    Load just the summary for an experiment, preferring the cache.
+
+    Falls back to computing from ``df`` (or loading runs) on a cache miss.
+    """
+    if use_cache:
+        cached = compact.load(experiment_name)
+        if cached is not None:
+            _df, _meta, summary = cached
+            return summary
+
+    analyzer = BenchmarkAnalyzer()
+    return analyzer.get_experiment_summary(experiment_name, df=df)
+
+
+def load_all_experiments_with_summaries(
+    limit: int = 10,
+    use_cache: bool = True,
+) -> list[dict]:
     """
     Load recent experiments with their summary statistics.
 
     Args:
         limit: Maximum number of experiments to load (default: 10)
+        use_cache: If True, consult the compaction cache for each experiment
 
     Returns:
         List of dicts with experiment info and summaries
@@ -45,7 +91,6 @@ def load_all_experiments_with_summaries(limit: int = 10) -> list[dict]:
         print("No experiments found")
         return []
 
-    # Limit to most recent experiments
     total_experiments = len(experiments)
     experiments = experiments.head(limit)
 
@@ -54,9 +99,25 @@ def load_all_experiments_with_summaries(limit: int = 10) -> list[dict]:
     for i, (_, exp_row) in enumerate(experiments.iterrows()):
         exp_name = exp_row["name"]
         print(f"  [{i+1}/{len(experiments)}] Loading {exp_name}...")
+
+        # Cache fast-path
+        if use_cache:
+            cached = compact.load(exp_name)
+            if cached is not None:
+                _df, metadata, summary = cached
+                results.append({
+                    "name": exp_name,
+                    "creation_time": exp_row["creation_time"],
+                    "summary": summary,
+                    "metadata": metadata,
+                })
+                print(f"    ✓ {summary['total_runs']} runs (cached)")
+                continue
+
         try:
-            summary = analyzer.get_experiment_summary(exp_name)
             metadata = analyzer.get_experiment_metadata(exp_name)
+            df = analyzer.load_experiment(exp_name)
+            summary = analyzer.get_experiment_summary(exp_name, df=df)
 
             results.append({
                 "name": exp_name,
@@ -64,6 +125,8 @@ def load_all_experiments_with_summaries(limit: int = 10) -> list[dict]:
                 "summary": summary,
                 "metadata": metadata,
             })
+            if use_cache:
+                compact.save(exp_name, df, metadata, summary)
             print(f"    ✓ Loaded {summary['total_runs']} runs")
         except Exception as e:
             print(f"    ✗ Failed to load: {e}")

--- a/packages/railroad/src/railroad/bench/dashboard/helpers.py
+++ b/packages/railroad/src/railroad/bench/dashboard/helpers.py
@@ -180,6 +180,33 @@ def build_experiment_summary_block(exp_name: str, summary: dict, metadata: dict,
             className="pre-text text-base text-dimmed"
         ))
 
+    # Run name (if provided and not the sentinel "None")
+    run_name = metadata.get("run_name")
+    if run_name and run_name != "None":
+        children.append(html.Pre(
+            f"  Run name: {run_name}",
+            className="pre-text text-base text-dimmed"
+        ))
+
+    # Git provenance (branch + commit hash)
+    git_branch = metadata.get("git_branch")
+    git_hash = metadata.get("git_hash")
+    git_dirty = metadata.get("git_dirty")
+    if git_branch or git_hash:
+        parts = []
+        if git_branch and git_branch != "unknown":
+            parts.append(f"branch={git_branch}")
+        if git_hash and git_hash != "unknown":
+            short_hash = git_hash[:8] if len(git_hash) > 8 else git_hash
+            parts.append(f"commit={short_hash}")
+        if git_dirty in (True, "True", "true"):
+            parts.append("(dirty)")
+        if parts:
+            children.append(html.Pre(
+                "  Git: " + " ".join(parts),
+                className="pre-text text-base text-dimmed"
+            ))
+
     # Total runs and success rate
     success_rate_class = "status-success" if summary['success_rate'] > 0.8 else ("status-error" if summary['success_rate'] > 0.5 else "status-failure")
     children.append(html.Pre([

--- a/packages/railroad/src/railroad/bench/runner.py
+++ b/packages/railroad/src/railroad/bench/runner.py
@@ -40,6 +40,7 @@ class BenchmarkRunner:
         tags: Optional[List[str]] = None,
         case_filter: Optional[str] = None,
         include_files: Optional[List[str]] = None,
+        run_name: Optional[str] = None,
     ):
         """
         Initialize benchmark runner.
@@ -52,6 +53,7 @@ class BenchmarkRunner:
             tags: Filter benchmarks by tags (default: None, run all)
             case_filter: Filter cases by matching against benchmark name and parameters (default: None)
             include_files: List of additional benchmark files to load (default: None)
+            run_name: Human-readable name for this benchmark run (default: None, auto-generated from timestamp)
         """
         self.benchmarks = benchmarks
         self.repeat_max = repeat_max
@@ -62,6 +64,7 @@ class BenchmarkRunner:
         self.filter_tags = tags
         self.case_filter = case_filter
         self.include_files = include_files
+        self.run_name = run_name
 
     def create_plan(self) -> ExecutionPlan:
         """
@@ -218,12 +221,24 @@ class BenchmarkRunner:
         except Exception:
             git_dirty = True
 
+        try:
+            git_branch = subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=Path(__file__).parent.parent.parent,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except Exception:
+            git_branch = "unknown"
+
         return {
             "timestamp": time.time(),
             "hostname": socket.gethostname(),
             "user": getpass.getuser(),
             "git_hash": git_hash,
+            "git_branch": git_branch,
             "git_dirty": git_dirty,
+            "run_name": self.run_name if self.run_name is not None else "None",
             "repeat_max": self.repeat_max if self.repeat_max is not None else "None",
             "parallel_workers": self.parallel,
             "num_benchmarks": len(self.benchmarks),
@@ -250,8 +265,12 @@ class BenchmarkRunner:
         Returns:
             Completed execution plan with results
         """
-        # Create MLflow experiment with timestamp
-        experiment_name = f"railroad_bench_{int(time.time())}"
+        # Create MLflow experiment, named by user if provided else timestamped
+        timestamp = int(time.time())
+        if self.run_name:
+            experiment_name = f"{self.run_name}_{timestamp}"
+        else:
+            experiment_name = f"railroad_bench_{timestamp}"
         self.tracker.create_experiment(experiment_name, plan.metadata)
 
         # Start progress display

--- a/packages/railroad/src/railroad/bench/tracking.py
+++ b/packages/railroad/src/railroad/bench/tracking.py
@@ -77,6 +77,9 @@ class MLflowTracker:
             else:
                 # Convert metadata to string tags (MLflow only supports string tags)
                 tags = {k: str(v) for k, v in metadata.items()}
+                # Marker tag so we can identify railroad-managed experiments
+                # regardless of their (possibly user-supplied) name.
+                tags["railroad_bench"] = "1"
                 self.experiment_id = mlflow.create_experiment(  # type: ignore[possibly-missing-attribute]
                     name=name,
                     tags=tags,

--- a/packages/railroad/src/railroad/cli.py
+++ b/packages/railroad/src/railroad/cli.py
@@ -85,6 +85,8 @@ def benchmarks() -> None:
               help="MLflow tracking URI (default: sqlite:///mlflow.db)")
 @click.option("--include", "-i", multiple=True, type=click.Path(exists=True),
               help="Include benchmark file(s) in addition to entry points (can be repeated)")
+@click.option("--run-name", default=None,
+              help="Human-readable name for this benchmark run (used in MLflow experiment name)")
 def benchmarks_run(
     case_filter: str | None,
     repeat_max: int | None,
@@ -93,6 +95,7 @@ def benchmarks_run(
     dry_run: bool,
     mlflow_uri: str | None,
     include: tuple[str, ...],
+    run_name: str | None,
 ) -> None:
     """Run PDDL planning benchmarks."""
     import sys
@@ -119,6 +122,7 @@ def benchmarks_run(
         tags=tags_list,
         case_filter=case_filter,
         include_files=include_files,
+        run_name=run_name,
     )
 
     # Create plan

--- a/packages/railroad/src/railroad/cli.py
+++ b/packages/railroad/src/railroad/cli.py
@@ -145,6 +145,72 @@ def benchmarks_dashboard() -> None:
     run_dashboard()
 
 
+@benchmarks.command("compact")
+@click.option("--experiment", default=None,
+              help="Compact a single experiment by name (default: compact all eligible)")
+@click.option("--force", is_flag=True, default=False,
+              help="Invalidate existing caches before recomputing")
+@click.option("--mlflow-uri", default=None,
+              help="MLflow tracking URI (default: sqlite:///mlflow.db)")
+def benchmarks_compact(experiment: str | None, force: bool, mlflow_uri: str | None) -> None:
+    """Materialize the compaction cache for finished experiments."""
+    from railroad.bench.analysis import BenchmarkAnalyzer
+    from railroad.bench import compact
+
+    analyzer = BenchmarkAnalyzer(tracking_uri=mlflow_uri)
+
+    if experiment:
+        names = [experiment]
+    else:
+        exps = analyzer.list_experiments()
+        if exps.empty:
+            click.echo("No experiments found.")
+            return
+        names = exps["name"].tolist()
+
+    from railroad.bench.dashboard.figures import create_violin_plots_by_benchmark
+    from railroad.bench.dashboard.sweeps import create_all_sweep_plots
+
+    cached = 0
+    skipped = 0
+    failed = 0
+    for name in names:
+        if force:
+            compact.invalidate(name)
+        try:
+            df = analyzer.load_experiment(name)
+            metadata = analyzer.get_experiment_metadata(name)
+            summary = analyzer.get_experiment_summary(name, df=df)
+            figures = {
+                "violin": create_violin_plots_by_benchmark(df),
+                "sweep": create_all_sweep_plots(df),
+            }
+            if compact.save(name, df, metadata, summary, figures=figures):
+                click.echo(f"  ✓ {name} ({summary['total_runs']} runs, figures cached)")
+                cached += 1
+            else:
+                click.echo(f"  ⏭  {name} (in-progress, skipped)")
+                skipped += 1
+        except Exception as e:
+            click.echo(f"  ✗ {name}: {e}")
+            failed += 1
+    click.echo(f"\nCompacted {cached} experiment(s), skipped {skipped}, failed {failed}.")
+
+
+@benchmarks.command("cache-clear")
+@click.option("--experiment", default=None,
+              help="Clear cache for a single experiment by name (default: clear all)")
+def benchmarks_cache_clear(experiment: str | None) -> None:
+    """Remove compacted cache files."""
+    from railroad.bench import compact
+    if experiment:
+        compact.invalidate(experiment)
+        click.echo(f"Cleared cache for '{experiment}'.")
+    else:
+        compact.invalidate_all()
+        click.echo("Cleared all benchmark caches.")
+
+
 def _make_example_command(name: str, info: ExampleInfo) -> None:
     """Create and register a click command for an example."""
     description = info["description"]


### PR DESCRIPTION
## Summary
- Add a `procthor_search` benchmark (multi-robot search in ProcTHOR scenes) plus a sweep over robots / heuristic mult / iterations / scene seeds (with scene_seed varying fastest so consecutive cases hit different scenes).
- Add a per-experiment compaction cache (`.benchmark_cache/<exp>/runs.parquet + meta.json + figures.json`) with mtime-fingerprint staleness checks; the dashboard reads from it before re-loading MLflow runs and re-rendering plots. Cache writes are blocked while any non-terminal run is still in progress.
- Add `--run-name` to `benchmarks run`; surface run name, git branch, commit hash, and dirty flag on the dashboard.
- Add `benchmarks compact` and `benchmarks cache-clear` CLI commands.
- Tag railroad-managed MLflow experiments with `railroad_bench=1` so user-named runs still appear in the dashboard listing (with a backward-compatible name-prefix fallback).

## Test plan
- [x] `uv run ty check` — All checks passed
- [x] `uv run pytest -m 'not slow'` — 223 passed, 1 xfailed
- [x] `uv run railroad benchmarks run --filter procthor_search --dry-run` — 180 cases enumerated
- [x] `uv run railroad benchmarks compact` over existing experiments (6 compacted), then verified the dashboard data path returns the cached `df`/`metadata`/`summary` and `compact.load_figures` round-trips cached violin + sweep plots
- [x] `uv run railroad benchmarks run --filter basic_planning --run-name smoke ...` — experiment listed as `smoke_<ts>` with `run_name=smoke`, branch, and short commit hash visible via the dashboard data layer