### PR TITLE
Reliable per-experiment
  dashboard caching + richer benchmark stats

### DIFF
--- a/packages/railroad/src/railroad/bench/analysis.py
+++ b/packages/railroad/src/railroad/bench/analysis.py
@@ -108,7 +108,8 @@ class BenchmarkAnalyzer:
             - total_runs: Total number of runs
             - benchmarks: List of benchmark names
             - success_rate: Overall success rate
-            - success_by_benchmark: Dict of success rates per benchmark
+            - success_by_benchmark: Per-benchmark dict of success_rate,
+              total_runs, avg_plan_cost, avg_wall_time
             - timeout_rate: Overall timeout rate
 
         Raises:
@@ -136,15 +137,25 @@ class BenchmarkAnalyzer:
         if "metrics.success" in df.columns:
             summary["success_rate"] = float(df["metrics.success"].mean())
 
-        # Success rate by benchmark
+        # Per-benchmark stats: success rate, run count, and (when present)
+        # average plan cost and wall time. Computed here so they land in the
+        # cached summary (meta.json) and the landing page never recomputes them.
         if "params.benchmark_name" in df.columns and "metrics.success" in df.columns:
-            success_by_bench = df.groupby("params.benchmark_name")["metrics.success"].agg(
-                ["mean", "count"]
-            )
+            grouped = df.groupby("params.benchmark_name")
+            success_by_bench = grouped["metrics.success"].agg(["mean", "count"])
+            has_cost = "metrics.plan_cost" in df.columns
+            has_wall = "metrics.wall_time" in df.columns
+
+            def _avg(bench: object, column: str) -> float | None:
+                vals = grouped.get_group(bench)[column].dropna()
+                return float(vals.mean()) if len(vals) > 0 else None
+
             summary["success_by_benchmark"] = {
                 bench: {
                     "success_rate": float(row["mean"]),
                     "total_runs": int(row["count"]),
+                    "avg_plan_cost": _avg(bench, "metrics.plan_cost") if has_cost else None,
+                    "avg_wall_time": _avg(bench, "metrics.wall_time") if has_wall else None,
                 }
                 for bench, row in success_by_bench.iterrows()
             }

--- a/packages/railroad/src/railroad/bench/compact.py
+++ b/packages/railroad/src/railroad/bench/compact.py
@@ -40,7 +40,8 @@ CACHE_DIR_NAME = ".benchmark_cache"
 # Bump whenever the on-disk cache layout (parquet columns, meta/figures JSON
 # shape, figure serialization) changes in a way that makes old caches
 # unreadable. A mismatch purges and rebuilds the cache transparently.
-CACHE_FORMAT_VERSION = 1
+# v2: summary.success_by_benchmark gained avg_plan_cost / avg_wall_time.
+CACHE_FORMAT_VERSION = 2
 
 # Per-experiment stamp file, written into the experiment's artifact directory.
 # Its contents change whenever the experiment's data changes, so a cache keyed

--- a/packages/railroad/src/railroad/bench/compact.py
+++ b/packages/railroad/src/railroad/bench/compact.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -36,9 +37,55 @@ from plotly.graph_objects import Figure
 
 CACHE_DIR_NAME = ".benchmark_cache"
 
+# Bump whenever the on-disk cache layout (parquet columns, meta/figures JSON
+# shape, figure serialization) changes in a way that makes old caches
+# unreadable. A mismatch purges and rebuilds the cache transparently.
+CACHE_FORMAT_VERSION = 1
+
+# Per-experiment stamp file, written into the experiment's artifact directory.
+# Its contents change whenever the experiment's data changes, so a cache keyed
+# on it is invalidated only by *that* experiment — unlike the shared
+# ``mlflow.db`` mtime, which every run (for any experiment) bumps.
+STAMP_FILENAME = ".railroad_cache_stamp"
+
 
 def _cache_dir() -> Path:
     return Path(CACHE_DIR_NAME)
+
+
+def _stamp_path(exp_name: str) -> Optional[Path]:
+    """Path to the experiment's cache stamp file, if its artifact dir resolves."""
+    art = _artifact_root(exp_name)
+    if art is None:
+        return None
+    return art / STAMP_FILENAME
+
+
+def touch_stamp(exp_name: str) -> None:
+    """Best-effort: record that ``exp_name``'s data just changed.
+
+    Writes the current wall-clock time into the experiment's stamp file. Called
+    from the tracker whenever runs/metadata are written. Failures are swallowed:
+    a missing stamp simply falls back to the legacy mtime fingerprint.
+    """
+    try:
+        path = _stamp_path(exp_name)
+        if path is None:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(repr(time.time()))
+    except Exception:
+        pass
+
+
+def remove_stamp(exp_name: str) -> None:
+    """Remove the stamp file for ``exp_name`` if present (best-effort)."""
+    try:
+        path = _stamp_path(exp_name)
+        if path is not None and path.exists():
+            path.unlink()
+    except Exception:
+        pass
 
 
 def _cache_paths(exp_name: str) -> tuple[Path, Path, Path]:
@@ -147,8 +194,27 @@ def _artifact_root(exp_name: str) -> Optional[Path]:
 
 
 def _source_fingerprint(exp_name: str) -> dict:
-    """A cheap stamp that changes whenever the experiment data changes."""
-    fp: dict = {}
+    """A cheap stamp that changes whenever the experiment data changes.
+
+    Preferred: the per-experiment stamp file, which only changes when *this*
+    experiment is written. This keeps unrelated benchmark runs from
+    invalidating every experiment's cache (the shared ``mlflow.db`` mtime did).
+
+    Fallback (no stamp yet — e.g. an experiment last run before this code, or
+    an artifact dir that doesn't resolve to the filesystem): the legacy
+    ``mlflow.db`` + artifact-dir mtime fingerprint, so old caches keep working
+    until that experiment's next run writes a stamp.
+    """
+    fp: dict = {"cache_format": CACHE_FORMAT_VERSION}
+
+    stamp = _stamp_path(exp_name)
+    if stamp is not None and stamp.exists():
+        try:
+            fp["stamp"] = stamp.read_text()
+            return fp
+        except Exception:
+            pass
+
     db = Path("mlflow.db")
     if db.exists():
         fp["db_mtime"] = db.stat().st_mtime
@@ -190,6 +256,10 @@ def load(exp_name: str) -> Optional[tuple[pd.DataFrame, dict, dict]]:
         df = pd.read_parquet(runs_path)
         return df, cached["metadata"], cached["summary"]
     except Exception:
+        # Corrupt / unreadable cache (e.g. truncated parquet, schema change):
+        # purge it so this same load rebuilds it cleanly instead of failing
+        # on every future load.
+        invalidate(exp_name)
         return None
 
 
@@ -213,6 +283,9 @@ def load_figures(exp_name: str) -> Optional[dict]:
             return None
         return _deserialize_figures(payload.get("figures", {}))
     except Exception:
+        # Unreadable figures cache (e.g. a serialization-format change):
+        # purge the whole experiment cache so it is rebuilt cleanly.
+        invalidate(exp_name)
         return None
 
 
@@ -285,3 +358,19 @@ def invalidate_all() -> None:
     d = _cache_dir()
     if d.exists():
         shutil.rmtree(d)
+
+
+def remove_all_stamps() -> None:
+    """Remove the stamp file from every railroad experiment (best-effort).
+
+    Forces a clean fingerprint baseline so the next load fully rebuilds.
+    """
+    try:
+        experiments = mlflow.search_experiments()  # type: ignore[possibly-missing-attribute]
+    except Exception:
+        return
+    for exp in experiments:
+        try:
+            remove_stamp(exp.name)
+        except Exception:
+            pass

--- a/packages/railroad/src/railroad/bench/dashboard/app.py
+++ b/packages/railroad/src/railroad/bench/dashboard/app.py
@@ -2,6 +2,8 @@
 Main entry point for the benchmark dashboard.
 """
 
+from pathlib import Path
+
 import dash
 import dash_bootstrap_components as dbc
 
@@ -52,11 +54,48 @@ def create_app() -> dash.Dash:
 app = create_app()
 
 
+def _reloader_scope() -> dict:
+    """Restrict the Werkzeug reloader to the ``dashboard/`` directory.
+
+    By default the reloader watches every imported module, so editing any file
+    in the (large) ``railroad`` package restarts the dashboard. We exclude the
+    rest of the package and watch only ``dashboard/`` so unrelated edits don't
+    trigger a restart.
+
+    Werkzeug's ``exclude_patterns`` are fnmatch globs where ``*`` also matches
+    ``/``, so a single pattern can't say "railroad but not dashboard". Instead
+    we exclude each non-dashboard sibling path explicitly (their absolute paths
+    are never prefixes of the dashboard path, so dashboard files survive the
+    filter), and pass the dashboard ``.py`` files via ``extra_files``.
+    """
+    dashboard_dir = Path(__file__).resolve().parent
+    bench_dir = dashboard_dir.parent
+    railroad_pkg = bench_dir.parent
+
+    exclude: list[str] = []
+    for child in railroad_pkg.iterdir():
+        if child != bench_dir:
+            exclude.append(f"{child}*")
+    for child in bench_dir.iterdir():
+        if child != dashboard_dir:
+            exclude.append(f"{child}*")
+
+    extra_files = [str(p) for p in dashboard_dir.rglob("*.py")]
+    return {"exclude_patterns": exclude, "extra_files": extra_files}
+
+
 def main():
     """Entry point for benchmarks-dashboard command."""
     print("\nStarting Dash server...")
     print("Open http://127.0.0.1:8050/ in your browser")
-    app.run(debug=True, dev_tools_ui=False, host="0.0.0.0")
+    run_options: dict = {}
+    try:
+        run_options = _reloader_scope()
+    except Exception as e:
+        # Any path/Werkzeug-signature surprise: fall back to the default
+        # (watch-everything) reloader rather than failing to start.
+        print(f"(reloader scoping disabled: {e})")
+    app.run(debug=True, dev_tools_ui=False, host="0.0.0.0", **run_options)
 
 
 if __name__ == "__main__":

--- a/packages/railroad/src/railroad/bench/dashboard/app.py
+++ b/packages/railroad/src/railroad/bench/dashboard/app.py
@@ -55,18 +55,22 @@ app = create_app()
 
 
 def _reloader_scope() -> dict:
-    """Restrict the Werkzeug reloader to the ``dashboard/`` directory.
+    """Restrict the Werkzeug reloader to the ``bench/`` package.
 
     By default the reloader watches every imported module, so editing any file
-    in the (large) ``railroad`` package restarts the dashboard. We exclude the
-    rest of the package and watch only ``dashboard/`` so unrelated edits don't
-    trigger a restart.
+    in the (large) ``railroad`` package restarts the dashboard. Issue #18 only
+    wanted to stop edits to the heavy *planning core* from restarting it — but
+    everything that feeds the dashboard (``analysis.py``, ``compact.py``,
+    ``runner.py``, the ``dashboard/`` UI) lives in ``bench/``. Watching the
+    whole ``bench/`` package means a code change that affects cached output
+    (e.g. a ``CACHE_FORMAT_VERSION`` bump) auto-restarts the server and the
+    cache rebuilds itself, instead of a stale process serving old data.
 
     Werkzeug's ``exclude_patterns`` are fnmatch globs where ``*`` also matches
-    ``/``, so a single pattern can't say "railroad but not dashboard". Instead
-    we exclude each non-dashboard sibling path explicitly (their absolute paths
-    are never prefixes of the dashboard path, so dashboard files survive the
-    filter), and pass the dashboard ``.py`` files via ``extra_files``.
+    ``/``, so a single pattern can't say "railroad but not bench". Instead we
+    exclude each non-``bench`` sibling path explicitly (their absolute paths
+    are never prefixes of the bench path, so bench files survive the filter),
+    and pass the ``bench/`` ``.py`` files via ``extra_files``.
     """
     dashboard_dir = Path(__file__).resolve().parent
     bench_dir = dashboard_dir.parent
@@ -76,11 +80,8 @@ def _reloader_scope() -> dict:
     for child in railroad_pkg.iterdir():
         if child != bench_dir:
             exclude.append(f"{child}*")
-    for child in bench_dir.iterdir():
-        if child != dashboard_dir:
-            exclude.append(f"{child}*")
 
-    extra_files = [str(p) for p in dashboard_dir.rglob("*.py")]
+    extra_files = [str(p) for p in bench_dir.rglob("*.py")]
     return {"exclude_patterns": exclude, "extra_files": extra_files}
 
 

--- a/packages/railroad/src/railroad/bench/dashboard/callbacks.py
+++ b/packages/railroad/src/railroad/bench/dashboard/callbacks.py
@@ -82,8 +82,9 @@ def register_callbacks(app):
         try:
             # Route to experiment list view or detail view
             if pathname == "/" or pathname is None:
-                # Show experiment list (limited to 10 most recent)
-                experiments = load_all_experiments_with_summaries(limit=10)
+                # Show experiment list (most recent; cheap now that per-run
+                # summaries are read from the on-disk cache)
+                experiments = load_all_experiments_with_summaries(limit=100)
                 content = build_experiment_list_layout(experiments)
                 return content, {}
 

--- a/packages/railroad/src/railroad/bench/dashboard/data.py
+++ b/packages/railroad/src/railroad/bench/dashboard/data.py
@@ -70,14 +70,14 @@ def load_experiment_summary(
 
 
 def load_all_experiments_with_summaries(
-    limit: int = 10,
+    limit: int = 100,
     use_cache: bool = True,
 ) -> list[dict]:
     """
     Load recent experiments with their summary statistics.
 
     Args:
-        limit: Maximum number of experiments to load (default: 10)
+        limit: Maximum number of experiments to load (default: 100)
         use_cache: If True, consult the compaction cache for each experiment
 
     Returns:

--- a/packages/railroad/src/railroad/bench/dashboard/helpers.py
+++ b/packages/railroad/src/railroad/bench/dashboard/helpers.py
@@ -118,13 +118,12 @@ def build_benchmark_stat_spans(bench_stats: dict) -> list:
             (optionally) avg_plan_cost and avg_wall_time.
 
     Returns:
-        List of Dash children: status symbols, run count, success rate, and
-        average plan cost / wall time when available.
+        List of Dash children: status symbols, run count, and success rate.
+        Average plan cost / wall time go on their own line via
+        :func:`build_benchmark_stats_line`.
     """
     success_rate = bench_stats.get("success_rate", 0.0)
     total_runs = bench_stats.get("total_runs", 0)
-    avg_cost = bench_stats.get("avg_plan_cost")
-    avg_wall = bench_stats.get("avg_wall_time")
 
     n_success = int(success_rate * total_runs)
     n_total = total_runs
@@ -138,16 +137,45 @@ def build_benchmark_stat_spans(bench_stats: dict) -> list:
         status_parts.append(html.Span(f"{SYMBOL_FAILURE}{n_failure}", className="status-failure"))
         status_parts.append("/")
 
-    spans: list = [
+    return [
         *status_parts,
         f"{n_total} ",
         html.Span(f"({success_rate:.1%})", className="text-dimmed"),
     ]
+
+
+def build_benchmark_stats_line(bench_stats: dict, indent: str = "      "):
+    """
+    Build the avg-cost / avg-wall-time line shown under a benchmark's name.
+
+    Rendered on its own indented line (like the benchmark description) rather
+    than crammed onto the status line. Returns ``None`` when neither stat is
+    available so callers can simply skip appending it.
+
+    Args:
+        bench_stats: Per-benchmark dict with (optionally) avg_plan_cost and
+            avg_wall_time.
+        indent: Leading whitespace to align the line with its section.
+    """
+    avg_cost = bench_stats.get("avg_plan_cost")
+    avg_wall = bench_stats.get("avg_wall_time")
+
+    segments: list[tuple[str, str]] = []
     if avg_cost is not None:
-        spans.append(html.Span(f"  cost {avg_cost:.2f}", className="text-dimmed"))
+        segments.append(("Avg. Cost: ", f"{avg_cost:.2f}"))
     if avg_wall is not None:
-        spans.append(html.Span(f"  t {avg_wall:.2f}s", className="text-dimmed"))
-    return spans
+        segments.append(("Avg. Time: ", f"{avg_wall:.2f}s"))
+    if not segments:
+        return None
+
+    children: list = [indent]
+    for i, (label, value) in enumerate(segments):
+        if i > 0:
+            children.append(" | ")
+        children.append(label)
+        children.append(html.Span(value, style={"color": CATPPUCCIN_SAPPHIRE}))
+
+    return html.Pre(children, className="pre-text text-base")
 
 
 def build_benchmark_summary_line(bench_name: str, bench_stats: dict, description: str = "") -> html.Pre:
@@ -255,6 +283,11 @@ def build_experiment_summary_block(exp_name: str, summary: dict, metadata: dict,
 
             # Benchmark line
             children.append(build_benchmark_summary_line(bench_name, bench_stats, description))
+
+            # Avg cost / time on its own line (like the description)
+            stats_line = build_benchmark_stats_line(bench_stats)
+            if stats_line is not None:
+                children.append(stats_line)
 
             # Description if available
             if description:

--- a/packages/railroad/src/railroad/bench/dashboard/helpers.py
+++ b/packages/railroad/src/railroad/bench/dashboard/helpers.py
@@ -105,28 +105,32 @@ def format_case_params(params: dict) -> str:
     return ", ".join(parts)
 
 
-def build_benchmark_summary_line(bench_name: str, bench_stats: dict, description: str = "") -> html.Pre:
+def build_benchmark_stat_spans(bench_stats: dict) -> list:
     """
-    Build a single benchmark summary line with status symbols.
+    Build the inline stat fragment shown after a benchmark's name.
+
+    Shared by the landing-page TOC, the per-experiment TOC, and each
+    per-benchmark section header so all three render identically and read
+    straight from the cached summary (no recompute).
 
     Args:
-        bench_name: Name of the benchmark
-        bench_stats: Dict with success_rate and total_runs
-        description: Optional description of the benchmark
+        bench_stats: Per-benchmark dict with success_rate, total_runs, and
+            (optionally) avg_plan_cost and avg_wall_time.
 
     Returns:
-        html.Pre element with formatted benchmark line
+        List of Dash children: status symbols, run count, success rate, and
+        average plan cost / wall time when available.
     """
     success_rate = bench_stats.get("success_rate", 0.0)
     total_runs = bench_stats.get("total_runs", 0)
+    avg_cost = bench_stats.get("avg_plan_cost")
+    avg_wall = bench_stats.get("avg_wall_time")
 
-    # Format success count with colored symbols
     n_success = int(success_rate * total_runs)
     n_total = total_runs
     n_failure = n_total - n_success
 
-    # Build status string with colored symbols
-    status_parts = []
+    status_parts: list = []
     if n_success > 0:
         status_parts.append(html.Span(f"{SYMBOL_SUCCESS}{n_success}", className="status-success"))
         status_parts.append("/")
@@ -134,12 +138,34 @@ def build_benchmark_summary_line(bench_name: str, bench_stats: dict, description
         status_parts.append(html.Span(f"{SYMBOL_FAILURE}{n_failure}", className="status-failure"))
         status_parts.append("/")
 
-    # Benchmark line
-    return html.Pre([
-        f"  {bench_name}: ",
+    spans: list = [
         *status_parts,
         f"{n_total} ",
         html.Span(f"({success_rate:.1%})", className="text-dimmed"),
+    ]
+    if avg_cost is not None:
+        spans.append(html.Span(f"  cost {avg_cost:.2f}", className="text-dimmed"))
+    if avg_wall is not None:
+        spans.append(html.Span(f"  t {avg_wall:.2f}s", className="text-dimmed"))
+    return spans
+
+
+def build_benchmark_summary_line(bench_name: str, bench_stats: dict, description: str = "") -> html.Pre:
+    """
+    Build a single benchmark summary line with status symbols.
+
+    Args:
+        bench_name: Name of the benchmark
+        bench_stats: Dict with success_rate, total_runs, avg_plan_cost,
+            avg_wall_time
+        description: Optional description of the benchmark
+
+    Returns:
+        html.Pre element with formatted benchmark line
+    """
+    return html.Pre([
+        f"  {bench_name}: ",
+        *build_benchmark_stat_spans(bench_stats),
     ], className="pre-text text-base")
 
 

--- a/packages/railroad/src/railroad/bench/dashboard/layouts.py
+++ b/packages/railroad/src/railroad/bench/dashboard/layouts.py
@@ -13,7 +13,11 @@ from .styles import (
     CATPPUCCIN_SAPPHIRE,
     TEXT_COLOR,
 )
-from .helpers import build_experiment_summary_block, build_benchmark_stat_spans
+from .helpers import (
+    build_experiment_summary_block,
+    build_benchmark_stat_spans,
+    build_benchmark_stats_line,
+)
 
 
 def create_log_modal() -> dbc.Modal:
@@ -155,6 +159,11 @@ def build_content_layout(
                     *build_benchmark_stat_spans(bench_stats),
                 ], className="pre-text text-base"))
 
+                # Avg cost / time on its own line (like the description)
+                stats_line = build_benchmark_stats_line(bench_stats)
+                if stats_line is not None:
+                    summary_children.append(stats_line)
+
                 # Description if available
                 if description:
                     summary_children.append(html.Pre(
@@ -189,6 +198,10 @@ def build_content_layout(
                 " ",
                 *build_benchmark_stat_spans(bench_stats),
             ], className="pre-text text-base"))
+
+            stats_line = build_benchmark_stats_line(bench_stats, indent="   ")
+            if stats_line is not None:
+                children.append(stats_line)
 
             if description:
                 children.append(html.Pre(

--- a/packages/railroad/src/railroad/bench/dashboard/layouts.py
+++ b/packages/railroad/src/railroad/bench/dashboard/layouts.py
@@ -12,10 +12,8 @@ from .styles import (
     CATPPUCCIN_BASE,
     CATPPUCCIN_SAPPHIRE,
     TEXT_COLOR,
-    SYMBOL_SUCCESS,
-    SYMBOL_FAILURE,
 )
-from .helpers import build_experiment_summary_block
+from .helpers import build_experiment_summary_block, build_benchmark_stat_spans
 
 
 def create_log_modal() -> dbc.Modal:
@@ -148,31 +146,13 @@ def build_content_layout(
             for bench_name in summary["benchmarks"]:
                 bench_stats = summary["success_by_benchmark"].get(bench_name, {})
                 description = benchmark_descriptions.get(bench_name, "")
-                success_rate = bench_stats.get("success_rate", 0.0)
-                total_runs = bench_stats.get("total_runs", 0)
-
-                # Format success count with colored symbols
-                n_success = int(success_rate * total_runs)
-                n_total = total_runs
-                n_failure = n_total - n_success
-
-                # Build status string with colored symbols
-                status_parts = []
-                if n_success > 0:
-                    status_parts.append(html.Span(f"{SYMBOL_SUCCESS}{n_success}", className="status-success"))
-                    status_parts.append("/")
-                if n_failure > 0:
-                    status_parts.append(html.Span(f"{SYMBOL_FAILURE}{n_failure}", className="status-failure"))
-                    status_parts.append("/")
 
                 # Benchmark line with clickable link
                 summary_children.append(html.Pre([
                     "    ",
                     html.A(bench_name, href=f"#benchmark-{bench_name}", className="link"),
                     " ",
-                    *status_parts,
-                    f"{n_total} ",
-                    html.Span(f"({success_rate:.1%})", className="text-dimmed"),
+                    *build_benchmark_stat_spans(bench_stats),
                 ], className="pre-text text-base"))
 
                 # Description if available
@@ -202,29 +182,12 @@ def build_content_layout(
             benchmark_descriptions = metadata.get("benchmark_descriptions", {})
             description = benchmark_descriptions.get(bench_name, "")
 
-            success_rate = bench_stats.get("success_rate", 0.0)
-            total_runs = bench_stats.get("total_runs", 0)
-            n_success = int(success_rate * total_runs)
-            n_total = total_runs
-            n_failure = n_total - n_success
-
-            # Build status string
-            status_parts = []
-            if n_success > 0:
-                status_parts.append(html.Span(f"{SYMBOL_SUCCESS}{n_success}", className="status-success"))
-                status_parts.append("/")
-            if n_failure > 0:
-                status_parts.append(html.Span(f"{SYMBOL_FAILURE}{n_failure}", className="status-failure"))
-                status_parts.append("/")
-
-            # Benchmark header with anchor
+            # Benchmark header with anchor (repeats the TOC stats per section)
             children.append(html.Div(id=f"benchmark-{bench_name}"))
             children.append(html.Pre([
                 html.Span(f"## {bench_name}", className="text-bold text-underline"),
                 " ",
-                *status_parts,
-                f"{n_total} ",
-                html.Span(f"({success_rate:.1%})", className="text-dimmed"),
+                *build_benchmark_stat_spans(bench_stats),
             ], className="pre-text text-base"))
 
             if description:

--- a/packages/railroad/src/railroad/bench/tracking.py
+++ b/packages/railroad/src/railroad/bench/tracking.py
@@ -89,6 +89,24 @@ class MLflowTracker:
         finally:
             sys.stderr = _stderr
 
+        self._touch_cache_stamp()
+
+    def _touch_cache_stamp(self) -> None:
+        """Bump this experiment's compaction-cache stamp (best-effort).
+
+        Lazily imported to avoid pulling the dashboard/compact stack at module
+        import time. Keeps the per-experiment cache valid across unrelated runs
+        while still invalidating as soon as *this* experiment's data changes.
+        """
+        if not self.experiment_name:
+            return
+        try:
+            from railroad.bench import compact
+
+            compact.touch_stamp(self.experiment_name)
+        except Exception:
+            pass
+
     def log_task(self, task: Task):
         """
         Log a single task execution as an MLflow run.
@@ -185,6 +203,8 @@ class MLflowTracker:
             if task.error:
                 mlflow.log_param("error_message", task.error[:500])  # type: ignore[possibly-missing-attribute]
 
+        self._touch_cache_stamp()
+
     def log_summary(self, summary: Dict[str, Any]):
         """
         Log experiment-level summary as a special run.
@@ -196,3 +216,5 @@ class MLflowTracker:
             # Log all summary values as metrics
             metrics = {k: float(v) for k, v in summary.items() if isinstance(v, (int, float))}
             mlflow.log_metrics(metrics)  # type: ignore[possibly-missing-attribute]
+
+        self._touch_cache_stamp()

--- a/packages/railroad/src/railroad/cli.py
+++ b/packages/railroad/src/railroad/cli.py
@@ -211,6 +211,27 @@ def benchmarks_cache_clear(experiment: str | None) -> None:
         click.echo("Cleared all benchmark caches.")
 
 
+@benchmarks.command("cache-flush")
+@click.option("--experiment", default=None,
+              help="Flush cache for a single experiment by name (default: flush all)")
+def benchmarks_cache_flush(experiment: str | None) -> None:
+    """Fully reset benchmark caches.
+
+    Like ``cache-clear``, but also removes the per-experiment stamp files, so
+    the cache fingerprint baseline is rebuilt from scratch on the next load. A
+    running dashboard rebuilds lazily on its next request.
+    """
+    from railroad.bench import compact
+    if experiment:
+        compact.invalidate(experiment)
+        compact.remove_stamp(experiment)
+        click.echo(f"Flushed cache and stamp for '{experiment}'.")
+    else:
+        compact.invalidate_all()
+        compact.remove_all_stamps()
+        click.echo("Flushed all benchmark caches and stamps.")
+
+
 def _make_example_command(name: str, info: ExampleInfo) -> None:
     """Create and register a click command for an example."""
     description = info["description"]

--- a/packages/railroad/tests/bench/test_compact.py
+++ b/packages/railroad/tests/bench/test_compact.py
@@ -1,0 +1,106 @@
+"""Tests for the benchmark compaction cache (railroad.bench.compact).
+
+These focus on the per-experiment stamp-file fingerprint introduced to stop
+unrelated benchmark runs from invalidating every experiment's cache, plus the
+purge-on-corruption and cache-format behaviors.
+"""
+
+import pandas as pd
+import pytest
+
+from railroad.bench import compact
+
+
+@pytest.fixture
+def cache_env(tmp_path, monkeypatch):
+    """Isolate the cache dir and point the artifact root at a tmp dir."""
+    cache_dir = tmp_path / ".benchmark_cache"
+    artifact_dir = tmp_path / "mlruns" / "1"
+    artifact_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(compact, "_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr(compact, "_artifact_root", lambda exp: artifact_dir)
+    return tmp_path, artifact_dir
+
+
+def _df():
+    return pd.DataFrame({"status": ["FINISHED", "FINISHED"], "x": [1, 2]})
+
+
+def test_stamp_drives_invalidation(cache_env):
+    """Cache hits while the stamp is unchanged, misses once it's touched."""
+    compact.touch_stamp("exp")
+    assert compact.save("exp", _df(), {"m": 1}, {"total_runs": 2})
+
+    loaded = compact.load("exp")
+    assert loaded is not None
+    df, meta, summary = loaded
+    assert len(df) == 2 and meta == {"m": 1} and summary["total_runs"] == 2
+
+    # An unrelated run does NOT touch this experiment's stamp -> still a hit.
+    assert compact.load("exp") is not None
+
+    # This experiment's data changes -> stamp bumps -> cache miss.
+    compact.touch_stamp("exp")
+    assert compact.load("exp") is None
+
+
+def test_corrupt_meta_purges_cache(cache_env):
+    compact.touch_stamp("exp")
+    assert compact.save("exp", _df(), {}, {})
+    runs_path, meta_path, _ = compact._cache_paths("exp")
+    meta_path.write_text("{ not json")
+
+    assert compact.load("exp") is None
+    # Whole experiment cache dir purged so the next load rebuilds cleanly.
+    assert not meta_path.parent.exists()
+
+
+def test_corrupt_figures_purges_cache(cache_env):
+    compact.touch_stamp("exp")
+    assert compact.save("exp", _df(), {}, {}, figures={})
+    _runs, _meta, figures_path = compact._cache_paths("exp")
+    figures_path.write_text("{ not json")
+
+    assert compact.load_figures("exp") is None
+    assert not figures_path.parent.exists()
+
+
+def test_cache_format_bump_invalidates_without_purge(cache_env, monkeypatch):
+    compact.touch_stamp("exp")
+    assert compact.save("exp", _df(), {}, {})
+
+    monkeypatch.setattr(compact, "CACHE_FORMAT_VERSION", compact.CACHE_FORMAT_VERSION + 1)
+    # A format bump is a normal fingerprint mismatch: miss, but not a purge
+    # (save() overwrites it on the rebuild).
+    assert compact.load("exp") is None
+    runs_path, _meta, _fig = compact._cache_paths("exp")
+    assert runs_path.exists()
+
+
+def test_fallback_fingerprint_without_artifact_root(tmp_path, monkeypatch):
+    """With no resolvable artifact root, the legacy fingerprint still works."""
+    cache_dir = tmp_path / ".benchmark_cache"
+    monkeypatch.setattr(compact, "_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr(compact, "_artifact_root", lambda exp: None)
+
+    fp = compact._source_fingerprint("exp")
+    assert fp["cache_format"] == compact.CACHE_FORMAT_VERSION
+    assert "stamp" not in fp
+
+    assert compact.save("exp", _df(), {"m": 2}, {"total_runs": 2})
+    loaded = compact.load("exp")
+    assert loaded is not None and loaded[1] == {"m": 2}
+
+
+def test_remove_stamp_roundtrip(cache_env):
+    _tmp, artifact_dir = cache_env
+    stamp = artifact_dir / compact.STAMP_FILENAME
+
+    compact.touch_stamp("exp")
+    assert stamp.exists()
+
+    compact.remove_stamp("exp")
+    assert not stamp.exists()
+    # Idempotent.
+    compact.remove_stamp("exp")

--- a/packages/railroad/tests/bench/test_summary_stats.py
+++ b/packages/railroad/tests/bench/test_summary_stats.py
@@ -8,7 +8,10 @@ and per-section headers.
 import pandas as pd
 
 from railroad.bench.analysis import BenchmarkAnalyzer
-from railroad.bench.dashboard.helpers import build_benchmark_stat_spans
+from railroad.bench.dashboard.helpers import (
+    build_benchmark_stat_spans,
+    build_benchmark_stats_line,
+)
 
 
 def _spans_text(spans: list) -> str:
@@ -47,24 +50,38 @@ def test_summary_missing_metric_columns_yield_none():
     assert a["avg_plan_cost"] is None and a["avg_wall_time"] is None
 
 
-def test_stat_spans_render_cost_and_time_when_present():
+def test_stat_spans_carry_only_status_and_rate():
+    """Cost/time moved to their own line, not the status span."""
     text = _spans_text(build_benchmark_stat_spans({
         "success_rate": 0.5,
         "total_runs": 2,
         "avg_plan_cost": 15.0,
         "avg_wall_time": 2.0,
     }))
-    assert "cost 15.00" in text
-    assert "t 2.00s" in text
     assert "50.0%" in text
+    assert "cost" not in text and "time" not in text
 
 
-def test_stat_spans_omit_missing_stats():
-    text = _spans_text(build_benchmark_stat_spans({
-        "success_rate": 1.0,
-        "total_runs": 1,
-        "avg_plan_cost": None,
-        "avg_wall_time": None,
-    }))
-    assert "cost" not in text
-    assert "t " not in text
+def test_stats_line_renders_cost_and_time_on_its_own_line():
+    line = build_benchmark_stats_line({
+        "avg_plan_cost": 15.0,
+        "avg_wall_time": 2.0,
+    }, indent="  ")
+    assert line is not None
+    text = _spans_text(line.children)
+    assert line.children[0] == "  "
+    assert "Avg. Cost:" in text and "15.00" in text
+    assert "Avg. Time:" in text and "2.00s" in text
+    assert "|" in text
+
+
+def test_stats_line_single_stat_has_no_separator():
+    line = build_benchmark_stats_line({"avg_plan_cost": 7.0, "avg_wall_time": None})
+    text = _spans_text(line.children)
+    assert "Avg. Cost:" in text and "7.00" in text
+    assert "Avg. Time:" not in text and "|" not in text
+
+
+def test_stats_line_none_when_no_stats():
+    assert build_benchmark_stats_line({"avg_plan_cost": None, "avg_wall_time": None}) is None
+    assert build_benchmark_stats_line({}) is None

--- a/packages/railroad/tests/bench/test_summary_stats.py
+++ b/packages/railroad/tests/bench/test_summary_stats.py
@@ -1,0 +1,70 @@
+"""Per-benchmark summary stats + their shared dashboard rendering.
+
+Covers the avg_plan_cost / avg_wall_time fields added to the cached summary
+and the shared stat-span renderer used by the landing TOC, experiment TOC,
+and per-section headers.
+"""
+
+import pandas as pd
+
+from railroad.bench.analysis import BenchmarkAnalyzer
+from railroad.bench.dashboard.helpers import build_benchmark_stat_spans
+
+
+def _spans_text(spans: list) -> str:
+    out = []
+    for s in spans:
+        if isinstance(s, str):
+            out.append(s)
+        else:  # html.Span
+            out.append(str(s.children))
+    return " ".join(out)
+
+
+def test_summary_includes_avg_cost_and_wall_time():
+    df = pd.DataFrame({
+        "params.benchmark_name": ["a", "a", "b", "b"],
+        "metrics.success": [1.0, 0.0, 1.0, 1.0],
+        "metrics.plan_cost": [10.0, 20.0, 4.0, 6.0],
+        "metrics.wall_time": [1.0, 3.0, 2.0, 2.0],
+    })
+    summary = BenchmarkAnalyzer().get_experiment_summary("exp", df=df)
+
+    a = summary["success_by_benchmark"]["a"]
+    b = summary["success_by_benchmark"]["b"]
+    assert a["avg_plan_cost"] == 15.0 and a["avg_wall_time"] == 2.0
+    assert a["success_rate"] == 0.5 and a["total_runs"] == 2
+    assert b["avg_plan_cost"] == 5.0 and b["avg_wall_time"] == 2.0
+
+
+def test_summary_missing_metric_columns_yield_none():
+    df = pd.DataFrame({
+        "params.benchmark_name": ["a", "a"],
+        "metrics.success": [1.0, 1.0],
+    })
+    summary = BenchmarkAnalyzer().get_experiment_summary("exp", df=df)
+    a = summary["success_by_benchmark"]["a"]
+    assert a["avg_plan_cost"] is None and a["avg_wall_time"] is None
+
+
+def test_stat_spans_render_cost_and_time_when_present():
+    text = _spans_text(build_benchmark_stat_spans({
+        "success_rate": 0.5,
+        "total_runs": 2,
+        "avg_plan_cost": 15.0,
+        "avg_wall_time": 2.0,
+    }))
+    assert "cost 15.00" in text
+    assert "t 2.00s" in text
+    assert "50.0%" in text
+
+
+def test_stat_spans_omit_missing_stats():
+    text = _spans_text(build_benchmark_stat_spans({
+        "success_rate": 1.0,
+        "total_runs": 1,
+        "avg_plan_cost": None,
+        "avg_wall_time": None,
+    }))
+    assert "cost" not in text
+    assert "t " not in text


### PR DESCRIPTION
Closes #18

  Keys the benchmark dashboard's compaction cache on a per-experiment stamp file instead of
  the shared mlflow.db mtime, so an unrelated run no longer invalidates every experiment's
  cache (the ~10s reload). Also purges corrupt caches, scopes the Werkzeug reloader to the
  dashboard dir, and adds 'benchmarks cache-flush'.

  Builds on that: per-benchmark avg cost / wall time computed into the cached summary and
  shown in the landing TOC, experiment TOC, and each section header; landing limit raised to
  100.

  Commits:
  - 6956557 Key dashboard cache on a per-experiment stamp file
  - b82d28f Show per-benchmark cost/time stats; raise landing limit to 100