### PR TITLE
Pin ty and ruff, fix type error from ty 0.0.64

### DIFF
--- a/packages/railroad/src/railroad/environment/procthor/learning/utils.py
+++ b/packages/railroad/src/railroad/environment/procthor/learning/utils.py
@@ -81,7 +81,8 @@ def get_sentence_embedding(sentence: str) -> np.ndarray:
     global _SENTENCE_MODEL
     if _SENTENCE_MODEL is None:
         _SENTENCE_MODEL = SentenceTransformer(model_dir.as_posix())
-    sentence_embedding = _SENTENCE_MODEL.encode([sentence])[0]
+    # encode() is typed as returning a Tensor though it yields numpy by default.
+    sentence_embedding = np.asarray(_SENTENCE_MODEL.encode([sentence])[0])
     file_path = _get_embedding_cache_dir() / f"{sentence}.npy"
     np.save(file_path, sentence_embedding)
     return sentence_embedding

--- a/packages/railroad/src/railroad/environment/procthor/scene.py
+++ b/packages/railroad/src/railroad/environment/procthor/scene.py
@@ -1,6 +1,6 @@
 """ProcTHOR scene data provider."""
 
-from typing import Callable, Dict, List, Set, Tuple
+from typing import Callable, Dict, Set, Tuple
 
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,12 @@ dependencies = [
     # Testing and formatting (monorepo-level)
     "pytest-html",
     "pytest-xdist>=3.8.0",
-    "ruff",
-    "ty>=0.0.12",
+    # ruff has no [tool.ruff] config here, so it runs on defaults; 0.16 widened the
+    # default rule set enough to surface ~1400 new findings. Pin until configured.
+    "ruff>=0.15.10,<0.16",
+    # uv.lock is gitignored, so CI re-resolves every run; without a ceiling a new
+    # ty release can break main on an unrelated commit. Bump deliberately.
+    "ty>=0.0.64,<0.0.65",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
uv.lock is gitignored, so CI re-resolves dependencies on every run. The unbounded `ty>=0.0.12` floor picked up ty 0.0.64 and broke main on an otherwise unrelated commit. Pin ty to 0.0.64 and hold ruff below 0.16, whose much wider default rule set surfaces ~1400 findings against this repo's (absent) [tool.ruff] config.

Fix the single error ty 0.0.64 reports: SentenceTransformer.encode() is typed as returning a Tensor, so wrap it in np.asarray to match the declared np.ndarray return type. It already yields numpy at runtime, so this is a no-op there. Also drop an unused typing.List import.