### PR TITLE
Serialise ProcTHOR scene generation and look for the cache where the resources are

### DIFF
--- a/packages/railroad/src/railroad/environment/procthor/_scene_lock.py
+++ b/packages/railroad/src/railroad/environment/procthor/_scene_lock.py
@@ -1,0 +1,85 @@
+"""One AI2-THOR simulator at a time, across processes.
+
+Building a scene that is not yet cached starts a Unity ``Controller``. That is
+heavy enough that several at once can take a machine down, and the benchmark
+runner happily fans out a dozen worker *processes* -- so a threading lock is no
+use here. This is an ``flock`` on a file beside the scene cache, which
+serialises scene generation across every process on the host, whatever started
+them.
+
+The lock is only taken on a cache miss, so a warm cache costs nothing. Callers
+must re-check the cache after acquiring it: whoever held it before may have
+generated exactly the scene we were about to.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+LOCK_FILENAME = ".scene-generation.lock"
+POLL_SECONDS = 1.0
+
+DEFAULT_TIMEOUT = float(os.environ.get("PROCTHOR_SCENE_LOCK_TIMEOUT", 1800.0))
+"""Long by default: generating a scene means starting Unity, and a queue of
+workers behind one slow generation is the normal case, not a stuck lock."""
+
+
+def lock_path() -> Path:
+    """Where the lock file lives -- beside the ProcTHOR-10k data."""
+    from .resources import get_procthor_10k_dir
+
+    return get_procthor_10k_dir() / LOCK_FILENAME
+
+
+@contextmanager
+def scene_generation_lock(
+    timeout: Optional[float] = None, path: Optional[Path] = None
+) -> Iterator[bool]:
+    """Hold the exclusive scene-generation lock for the duration of the block.
+
+    Yields True when the lock was held, False when it could not be taken (no
+    ``fcntl`` on this platform, an unwritable directory, or the timeout
+    elapsed). Failing open is deliberate: a locking problem should slow a
+    machine down, not stop a run that would otherwise have worked.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - not reachable on Linux/macOS
+        yield False
+        return
+
+    target = path or lock_path()
+    deadline = time.monotonic() + (DEFAULT_TIMEOUT if timeout is None else timeout)
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(target, "a+")
+    except OSError:
+        yield False
+        return
+
+    announced = False
+    try:
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    yield False
+                    return
+                if not announced:
+                    print("[procthor] waiting for another process to finish "
+                          "generating a scene...")
+                    announced = True
+                time.sleep(POLL_SECONDS)
+        try:
+            yield True
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -56,14 +56,27 @@ class ThorInterface:
 
         self.cached_data = self._load_cache() if use_cache else None
         if self.cached_data is None:
-            from ai2thor.controller import Controller
-            self.controller = Controller(
-                scene=self.scene,
-                gridSize=self.grid_resolution,
-                width=480,
-                height=480
-            )
-            self.cached_data = self._save_and_get_cache()
+            # Generating a scene starts a Unity controller. Several of those at
+            # once will take a machine down, and benchmark workers are separate
+            # processes, so this is a cross-process file lock rather than a
+            # threading one. Re-check the cache once we hold it: the process
+            # ahead of us in the queue may have generated this very scene.
+            from ._scene_lock import scene_generation_lock
+
+            with scene_generation_lock():
+                self.cached_data = self._load_cache() if use_cache else None
+                if self.cached_data is None:
+                    from ai2thor.controller import Controller
+                    self.controller = Controller(
+                        scene=self.scene,
+                        gridSize=self.grid_resolution,
+                        width=480,
+                        height=480
+                    )
+                    self.cached_data = self._save_and_get_cache()
+                else:
+                    print("-----------Using cached procthor data-----------")
+                    self.controller = None
         else:
             print("-----------Using cached procthor data-----------")
             self.controller = None

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -109,22 +109,33 @@ class ThorInterface:
             json_list = list(f)
         return json.loads(json_list[self.seed])
 
-    def _save_and_get_cache(self, path: str = './resources/procthor-10k/cache') -> Dict:
+    def _cache_dir(self) -> Path:
+        """Where per-seed scene caches live.
+
+        Derived from the resources directory rather than hardcoded relative to
+        the working directory, so ``PROCTHOR_RESOURCES_DIR`` actually reaches
+        it. Without that, running from anywhere but the directory holding
+        ``resources/`` silently misses every cached scene and starts Unity.
+        """
+        return get_procthor_10k_dir() / 'cache'
+
+    def _save_and_get_cache(self, path: Optional[str] = None) -> Dict:
         """Cache expensive computations."""
         cache = {
             'reachable_positions': self._get_reachable_positions_from_controller(),
             'image_ortho': self._get_top_down_image_from_controller(orthographic=True),
             'image_persp': self._get_top_down_image_from_controller(orthographic=False)
         }
-        save_dir = Path(path)
+        save_dir = Path(path) if path is not None else self._cache_dir()
         save_dir.mkdir(parents=True, exist_ok=True)
         with open(save_dir / f'scene_{self.seed}.pkl', 'wb') as f:
             pickle.dump(cache, f)
         return cache
 
-    def _load_cache(self, path: str = './resources/procthor-10k/cache') -> Optional[Dict]:
+    def _load_cache(self, path: Optional[str] = None) -> Optional[Dict]:
         """Load cached scene data."""
-        cache_file = Path(path) / f'scene_{self.seed}.pkl'
+        base = Path(path) if path is not None else self._cache_dir()
+        cache_file = base / f'scene_{self.seed}.pkl'
         if not cache_file.exists():
             return None
         with open(cache_file, 'rb') as f:

--- a/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
@@ -1,0 +1,62 @@
+"""Where the per-seed scene cache is looked for.
+
+The path used to be hardcoded relative to the working directory, so a run
+started from anywhere but the directory holding ``resources/`` silently missed
+every cached scene and generated it again -- slow at best, and on a headless
+machine a hard failure, for a scene that was sitting on disk the whole time.
+
+It follows the resources directory now, which is what ``PROCTHOR_RESOURCES_DIR``
+sets and what every other ProcTHOR asset already used.
+"""
+
+import pickle
+
+import pytest
+
+from railroad.environment.procthor import resources
+from railroad.environment.procthor.thor_interface import ThorInterface
+
+
+@pytest.fixture
+def cache_dir(tmp_path, monkeypatch):
+    """Point the resources base somewhere new, as the env var would.
+
+    The env var is read once at import, so the test moves the value it
+    produced rather than the variable.
+    """
+    monkeypatch.setattr(resources, "DEFAULT_RESOURCES_BASE", tmp_path / "elsewhere")
+    return tmp_path / "elsewhere" / "procthor-10k" / "cache"
+
+
+def _interface(seed: int) -> ThorInterface:
+    """A ThorInterface without ``__init__``, which would load a whole scene."""
+    thor = object.__new__(ThorInterface)
+    thor.seed = seed
+    return thor
+
+
+def test_the_cache_follows_the_resources_directory(cache_dir):
+    assert _interface(7)._cache_dir() == cache_dir
+
+
+def test_a_cached_scene_is_found_from_any_working_directory(
+    cache_dir, tmp_path, monkeypatch
+):
+    """The bug: this returned None, and the caller started Unity."""
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "scene_7.pkl").write_bytes(pickle.dumps({"reachable_positions": []}))
+
+    monkeypatch.chdir(tmp_path)  # anywhere but the directory holding resources/
+    assert _interface(7)._load_cache() == {"reachable_positions": []}
+
+
+def test_a_missing_scene_is_still_a_miss(cache_dir):
+    cache_dir.mkdir(parents=True)
+    assert _interface(7)._load_cache() is None
+
+
+def test_an_explicit_path_still_wins(cache_dir, tmp_path):
+    somewhere = tmp_path / "somewhere"
+    somewhere.mkdir()
+    (somewhere / "scene_3.pkl").write_bytes(pickle.dumps({"marker": True}))
+    assert _interface(3)._load_cache(str(somewhere)) == {"marker": True}

--- a/packages/railroad/tests/environment/procthor/test_scene_lock.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_lock.py
@@ -1,0 +1,107 @@
+"""Tests for the cross-process ProcTHOR scene-generation lock.
+
+Generating an uncached scene starts a Unity controller; several at once can
+take a machine down, and benchmark workers are separate processes. These check
+that the lock is real across processes and that it never becomes a way for a
+run to fail.
+
+Children report through append-only files rather than a multiprocessing
+Manager, which needs a socket and is not always available in a sandbox.
+CLOCK_MONOTONIC is system-wide on Linux, so the timestamps are comparable.
+"""
+
+import multiprocessing as mp
+import time
+from pathlib import Path
+
+import pytest
+
+from railroad.environment.procthor._scene_lock import scene_generation_lock
+
+
+def _hold(lock_str: str, log_str: str, hold_seconds: float) -> None:
+    with scene_generation_lock(path=Path(lock_str)) as held:
+        with open(log_str, "a") as handle:
+            handle.write(f"enter {held} {time.monotonic()}\n")
+            handle.flush()
+        time.sleep(hold_seconds)
+        with open(log_str, "a") as handle:
+            handle.write(f"exit {held} {time.monotonic()}\n")
+            handle.flush()
+
+
+def _wait_for(log: Path, token: str, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if log.exists() and token in log.read_text():
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"{token!r} never appeared in {log}")
+
+
+def _intervals(log: Path) -> list[tuple[float, float]]:
+    """(enter, exit) pairs in the order they were written."""
+    events = [line.split() for line in log.read_text().splitlines() if line]
+    assert all(held == "True" for _kind, held, _t in events), events
+    stack, spans = [], []
+    for kind, _held, stamp in events:
+        if kind == "enter":
+            stack.append(float(stamp))
+        else:
+            spans.append((stack.pop(), float(stamp)))
+    return spans
+
+
+def test_lock_is_exclusive_across_processes(tmp_path):
+    """The second process must wait for the first, not run alongside it."""
+    lock, log = tmp_path / "lock", tmp_path / "log"
+    ctx = mp.get_context("fork")
+
+    first = ctx.Process(target=_hold, args=(str(lock), str(log), 1.0))
+    first.start()
+    _wait_for(log, "enter")
+
+    second = ctx.Process(target=_hold, args=(str(lock), str(log), 0.0))
+    second.start()
+    first.join(timeout=30)
+    second.join(timeout=30)
+    assert first.exitcode == 0 and second.exitcode == 0
+
+    spans = _intervals(log)
+    assert len(spans) == 2, log.read_text()
+    (a_start, a_end), (b_start, b_end) = sorted(spans)
+    assert b_start >= a_end, (
+        f"the two processes overlapped inside the lock: {spans}"
+    )
+    assert b_end >= b_start
+
+
+def test_timeout_fails_open_rather_than_blocking_a_run(tmp_path):
+    """A lock we cannot take should slow things down, never stop them."""
+    lock, log = tmp_path / "lock", tmp_path / "log"
+    ctx = mp.get_context("fork")
+    holder = ctx.Process(target=_hold, args=(str(lock), str(log), 3.0))
+    holder.start()
+    _wait_for(log, "enter")
+
+    began = time.monotonic()
+    with scene_generation_lock(timeout=0.5, path=lock) as held:
+        assert held is False
+    assert time.monotonic() - began < 3.0, "should have given up, not waited it out"
+    holder.join(timeout=30)
+
+
+def test_an_unwritable_location_yields_false(tmp_path):
+    """Failing open: a locking problem must not stop a run that would work."""
+    (tmp_path / "not-a-dir").write_text("regular file")
+    with scene_generation_lock(path=tmp_path / "not-a-dir" / "nested" / "lock") as held:
+        assert held is False
+
+
+@pytest.mark.parametrize("timeout", [0.0, 0.5])
+def test_the_lock_is_released_on_exit(tmp_path, timeout):
+    """Otherwise the second scene of a sweep would hang forever."""
+    lock = tmp_path / "lock"
+    for _ in range(3):
+        with scene_generation_lock(timeout=timeout, path=lock) as held:
+            assert held is True


### PR DESCRIPTION
Two changes about the same moment: when a ProcTHOR cache miss turns into a Unity controller. The first stops misses that should never have happened; the second keeps the remaining ones from piling up.

## Serialise scene generation across processes

An uncached scene is built by starting a Unity controller. The benchmark runner fans out a dozen worker *processes*, so a cold cache meant a dozen Unity instances coming up at once — enough to take the machine down, and wasteful besides, since several workers often generate the same seed. An `flock` beside the ProcTHOR-10k data serialises this. A `threading` lock would not do: the contention is between processes the runner spawned, and in general between anything on the host touching these scenes.

Three properties worth a look during review:

- **Taken only on a cache miss**, so a warm cache costs nothing. The common case does not touch the filesystem beyond the read it was already doing.
- **The cache is re-checked after the lock is acquired.** Whoever held it before may have generated exactly the scene we were queued for; without the re-check the whole queue regenerates the same seed in turn.
- **It fails open.** No `fcntl`, an unwritable directory, or a timeout all yield `False` and carry on — a locking problem should slow a machine down, not stop a run that would otherwise have worked. The default timeout is 30 minutes, because a queue behind one slow generation is the normal case rather than a stuck lock; `PROCTHOR_SCENE_LOCK_TIMEOUT` overrides it.

Tests use append-only files and polling rather than `multiprocessing.Manager`, which needs a semaphore the sandbox here does not grant.

## Look for cached scenes where the resources actually are

`_load_cache` and `_save_and_get_cache` hardcoded `./resources/procthor-10k/cache`, relative to the working directory, while every other ProcTHOR asset goes through `get_procthor_10k_dir()` and honours `PROCTHOR_RESOURCES_DIR`. A run started from anywhere else found no cache and generated the scene again — slow at best, and on a headless machine a hard failure, for a pickle sitting on disk the whole time. Nothing reported it, because a cache miss is a legitimate outcome.

It follows the resources directory now. An explicit `path=` argument still wins, so any caller passing one is unaffected.

The two new tests fail against the old path and pass against this one — checked by reverting the source and re-running.

---

This branch previously also carried the video-compositing work; those five commits are now in `main` under their own SHAs, and the rebase dropped them as already-applied (all five verified patch-identical). What remains here is only the ProcTHOR change.
