### PR TITLE
Put the trajectory on the overhead image instead of beside it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,17 +50,18 @@ Provides abstractions for planning execution:
   - `protocols.py`: `MotionSkill` protocol, `SupportsMovePathEnvironment` contract
   - `navigation.py`: `NavigationMoveSkill` (path-following with occupancy-grid pathing), `InterruptibleNavigationMoveSkill` (interruptible variant)
 
-- **`types.py`**: Shared types (`Pose`, `PoseLike` protocol)
+- **`types.py`**: Shared types (`Pose`, `PoseLike` protocol, `TopDownView`)
 
 - **`procthor/`**: ProcTHOR simulator interface (optional dependency)
   - `ThorInterface`: Main underlying interface to AI2-THOR/ProcTHOR scenes
   - `ProcTHORScene`: User-facing data provider for ProcTHOR, wrapping ThorInterface
   - `ProcTHOREnvironment`: Subclass of `ObjectSearchEnvironment` + `OccupancyGridPathingMixin`; subclasses must override `define_operators()`
   - `SceneGraph`: Scene graph representation
+  - Overhead view: `get_top_down_view()` returns the orthographic image *plus* its footprint in grid cells, so the dashboard can draw trajectories on top of it. `top_down_footprint()` chooses that footprint from the room floor polygons in the scene JSON (squared up, plus `TOP_DOWN_MARGIN_M`) and the camera is *told* to frame exactly it — deliberately not AI2-THOR's map-view framing, which uses `sceneBounds` (the union of every enabled renderer, including geometry invisible from above) and is inconsistent across ProcTHOR-10k (allenai/ai2thor#1181). Because it is recomputable, the cached `image_ortho_extent_m` is checked against it on load: a missing or disagreeing extent returns `None` and warns once rather than misplacing pixels — delete `resources/procthor-10k/cache` to regenerate (needs a display)
 
 - **`railsim/`**: OpenGL visual simulator with procedural maze/office worlds (optional dependency, `railroad[railsim]`)
   - `Simulator`: Renders perspective and panoramic RGB/depth images at any meter-space pose (moderngl)
-  - `RailsimScene`: Data provider mirroring `ProcTHORScene` (`.grid`, `.locations`, `.object_locations`); `RailsimScene.maze(seed=...)` / `.office(seed=...)` constructors; navigation `grid` is the raw occupancy grid inflated by `inflation_radius_m` while rendering uses raw geometry
+  - `RailsimScene`: Data provider mirroring `ProcTHORScene` (`.grid`, `.locations`, `.object_locations`, `.get_top_down_view()`); `RailsimScene.maze(seed=...)` / `.office(seed=...)` constructors; navigation `grid` is the raw occupancy grid inflated by `inflation_radius_m` while rendering uses raw geometry
   - `VisualUnknownSpaceEnvironment`: `UnknownSpaceEnvironment` subclass that renders a panorama at every laser sensor step into `pano_records` (list of `PanoRecord`)
   - Coordinates: railroad environments work in grid cells; railsim renders in meters (`meters = cells * map_data.resolution`)
   - Example: `uv run railroad example visual-frontier-search --env maze|office`; rendering requires a working GL context (`RAILSIM_GL_BACKEND` to pin one)

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -56,6 +56,39 @@ class _PlottingMixin:
     _TRAIL_SIZE_START = 25.0
     _TRAIL_SIZE_END = 2.0
 
+    _TRAIL_OUTLINE_WIDTH_PT = 1.4
+    """Half-width of the white halo behind a trail, in points.
+
+    Wide enough to separate a trail from a busy scene image underneath,
+    narrow enough not to swallow the thin tail of the trail.
+    """
+
+    _TRAIL_REPAINT_OVERLAP = 64
+    """Trail points repainted behind each newly drawn batch, in the video.
+
+    Frames are composited incrementally: each one paints the newly revealed
+    points onto the previous frame's raster. The halo is wider than the trail,
+    so a batch's halo spills backwards over colours already on that raster.
+    Repainting a short run behind the batch covers the spill, and keeps the
+    per-frame cost proportional to what was revealed rather than to the whole
+    trail. Dense enough at 2000 points per trail that this is a small fraction
+    of one frame's work.
+    """
+
+    @classmethod
+    def _trail_outline_sizes(cls, sizes: Any) -> Any:
+        """Marker areas giving a constant-width halo around *sizes*.
+
+        Scatter sizes are areas, and a trail tapers from
+        ``_TRAIL_SIZE_START`` to ``_TRAIL_SIZE_END``, so scaling the area
+        would taper the halo along with it and leave the thin end unoutlined.
+        Growing the *radius* by a fixed amount keeps the outline even.
+        """
+        import numpy as np
+
+        radii = np.sqrt(np.asarray(sizes, dtype=float))
+        return (radii + 2.0 * cls._TRAIL_OUTLINE_WIDTH_PT) ** 2
+
     @staticmethod
     def _get_cmap(idx: int):
         """Return a truncated colormap starting at 0.25 for the idx-th entry."""
@@ -447,10 +480,23 @@ class _PlottingMixin:
         # Draw one combined scatter for all robot trails, sorted by time
         if trail is not None:
             combined_xy, combined_sizes, combined_colors, _combined_times = trail
+            # A white halo underneath, so the trail reads against whatever it
+            # crosses -- a scene image is busy and every trail colour appears
+            # somewhere in it. Drawn as one layer below the whole trail rather
+            # than as a per-marker stroke: markers overlap, so a stroke would
+            # paint over the neighbour drawn just before it and scallop the
+            # line.
+            ax.scatter(
+                combined_xy[:, 0], combined_xy[:, 1],
+                s=self._trail_outline_sizes(combined_sizes), c="white",
+                zorder=4.5, linewidths=0,
+            )
+            # Opaque, so the halo stays an outline instead of washing the
+            # colours out from behind.
             ax.scatter(
                 combined_xy[:, 0], combined_xy[:, 1],
                 s=combined_sizes, c=combined_colors,
-                zorder=5, alpha=0.7,
+                zorder=5,
             )
 
         # Optionally plot object trajectories
@@ -1115,6 +1161,11 @@ class _PlottingMixin:
         # never takes its single-element "stamp one marker" shortcut: that
         # shortcut antialiases slightly differently, which would show up
         # whenever a frame happens to add exactly one trail point.
+        # Revealed by the same time prefix as the trail below it, so the halo
+        # never runs ahead of the path it is outlining.
+        trail_outline = ax.scatter([], [], s=[], c="white", zorder=4.5,
+                                   linewidths=0, alpha=1.0)
+        trail_outline.set_antialiased([True, True])
         trail_scatter = ax.scatter([], [], s=[], zorder=5, alpha=1.0)
         trail_scatter.set_antialiased([True, True])
 
@@ -1261,7 +1312,8 @@ class _PlottingMixin:
         # instead. (Hiding the rest would move the title, whose placement
         # consults the tick bboxes.)
         layered: list[Any] = [
-            *stack_artists, *onboard_list, *hot_artists, trail_scatter,
+            *stack_artists, *onboard_list, *hot_artists,
+            trail_outline, trail_scatter,
         ]
         for artist in layered:
             artist.set_animated(True)
@@ -1289,10 +1341,30 @@ class _PlottingMixin:
             drawn_onboard_sizes = _onboard_sizes()
             return canvas.copy_from_bbox(fig.bbox)
 
-        def _set_trail(lo: int, hi: int) -> None:
-            trail_scatter.set_offsets(combined_xy[lo:hi])
-            trail_scatter.set_sizes(combined_sizes[lo:hi])
-            trail_scatter.set_facecolors(combined_colors[lo:hi])
+        def _draw_trail(lo: int, hi: int) -> None:
+            """Draw trail points ``[lo, hi)``: white halo first, then colour.
+
+            Only the new points, so a frame costs what it revealed rather than
+            the whole trail. Their halo does spill backwards over colours
+            already on the raster, so the colour pass starts a little earlier
+            than the halo pass and paints that spill back in.
+
+            What the overlap does not reach is a path *crossing*: there the new
+            halo covers an older segment that is nowhere near it in time. That
+            is left alone deliberately -- it is what makes the later path read
+            as passing over the earlier one, which is the whole reason for
+            outlining a line, and redrawing every colour to avoid it would cost
+            more than the outline itself.
+            """
+            trail_outline.set_offsets(combined_xy[lo:hi])
+            trail_outline.set_sizes(self._trail_outline_sizes(combined_sizes[lo:hi]))
+            fig.draw_artist(trail_outline)
+
+            start = max(0, lo - self._TRAIL_REPAINT_OVERLAP)
+            trail_scatter.set_offsets(combined_xy[start:hi])
+            trail_scatter.set_sizes(combined_sizes[start:hi])
+            trail_scatter.set_facecolors(combined_colors[start:hi])
+            fig.draw_artist(trail_scatter)
 
         chrome: Any = None
         stack: Any = None
@@ -1335,8 +1407,7 @@ class _PlottingMixin:
                     canvas.restore_region(chrome)
                 for artist in stack_artists:
                     fig.draw_artist(artist)
-                _set_trail(0, n_trail)
-                fig.draw_artist(trail_scatter)
+                _draw_trail(0, n_trail)
                 stack = canvas.copy_from_bbox(fig.bbox)
                 drawn_stack, drawn_trail = stack_key, n_trail
             else:
@@ -1344,8 +1415,7 @@ class _PlottingMixin:
                 if n_trail > drawn_trail:
                     # The trail only ever grows here, so draw the new points
                     # and fold them into the stack for the next frame.
-                    _set_trail(drawn_trail, n_trail)
-                    fig.draw_artist(trail_scatter)
+                    _draw_trail(drawn_trail, n_trail)
                     stack = canvas.copy_from_bbox(fig.bbox)
                     drawn_trail = n_trail
 

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -412,9 +412,17 @@ class _PlottingMixin:
                 ax, occupancy_grid, true_grid, translucent=photo is not None,
             )
             if photo is not None:
+                from railroad.navigation.plotting import (
+                    make_known_boundary_rgba, make_untraversable_shade_rgba,
+                )
+                # An image shows the room, not the map: darken what the robot
+                # cannot stand on so the space it can move through reads.
+                ax.imshow(
+                    make_untraversable_shade_rgba(occupancy_grid),
+                    origin="upper", zorder=0.25,
+                )
                 # The image renders ground truth everywhere, including where
                 # the robot has not looked, so outline how far it has seen.
-                from railroad.navigation.plotting import make_known_boundary_rgba
                 ax.imshow(
                     make_known_boundary_rgba(occupancy_grid),
                     origin="upper", zorder=0.5,
@@ -970,6 +978,7 @@ class _PlottingMixin:
         from railroad.navigation.plotting import (
             PHOTO_UNDERLAY_ALPHA, _BACKGROUND_GRAY, make_known_boundary_rgba,
             make_plotting_grid, make_plotting_grid_rgba,
+            make_untraversable_shade_rgba,
         )
 
         nav_grid_artist = None
@@ -1030,16 +1039,18 @@ class _PlottingMixin:
         # frame rather than the final state.
         known_boundary_artist = None
         known_boundary_frames: list[tuple[float, Any]] = []
+        shade_artist = None
+        shade_frames: list[tuple[float, Any]] = []
         if occupancy_grid is not None and photo_artist is not None:
-            if self._nav_grid_snapshots:
-                known_boundary_frames = [
-                    (t, make_known_boundary_rgba(g))
-                    for t, g in self._nav_grid_snapshots
-                ]
-                first = known_boundary_frames[0][1]
-            else:
-                first = make_known_boundary_rgba(occupancy_grid)
-            known_boundary_artist = ax.imshow(first, origin="upper", zorder=0.5)
+            for make, zorder in ((make_untraversable_shade_rgba, 0.25),
+                                 (make_known_boundary_rgba, 0.5)):
+                frames = [(t, make(g)) for t, g in self._nav_grid_snapshots]
+                first = frames[0][1] if frames else make(occupancy_grid)
+                artist = ax.imshow(first, origin="upper", zorder=zorder)
+                if zorder == 0.25:
+                    shade_artist, shade_frames = artist, frames
+                else:
+                    known_boundary_artist, known_boundary_frames = artist, frames
 
         # Animated frontier-probability overlay (LSP environments)
         frontier_overlay_artist = None
@@ -1225,10 +1236,12 @@ class _PlottingMixin:
                 if nav_idx != shown_idx["nav"]:
                     nav_grid_artist.set_data(nav_grid_frames[nav_idx][1])
                     shown_idx["nav"] = nav_idx
-                # Same snapshots, so the same index keeps the outline in step.
-                if (known_boundary_artist is not None and known_boundary_frames
-                        and nav_idx != shown_idx["boundary"]):
-                    known_boundary_artist.set_data(known_boundary_frames[nav_idx][1])
+                # Same snapshots, so the same index keeps these in step.
+                if nav_idx != shown_idx["boundary"]:
+                    for artist, frames in ((known_boundary_artist, known_boundary_frames),
+                                           (shade_artist, shade_frames)):
+                        if artist is not None and frames:
+                            artist.set_data(frames[nav_idx][1])
                     shown_idx["boundary"] = nav_idx
             # Frontier-probability overlay
             overlay_idx = -1
@@ -1301,7 +1314,7 @@ class _PlottingMixin:
         hot_artists.sort(key=lambda a: a.get_zorder())
 
         stack_artists: list[Any] = [
-            a for a in (nav_grid_artist, known_boundary_artist,
+            a for a in (nav_grid_artist, shade_artist, known_boundary_artist,
                         frontier_overlay_artist) if a is not None
         ]
         if stack_artists:

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -66,23 +66,19 @@ class _PlottingMixin:
     _TRAIL_REPAINT_OVERLAP = 64
     """Trail points repainted behind each newly drawn batch, in the video.
 
-    Frames are composited incrementally: each one paints the newly revealed
-    points onto the previous frame's raster. The halo is wider than the trail,
-    so a batch's halo spills backwards over colours already on that raster.
-    Repainting a short run behind the batch covers the spill, and keeps the
-    per-frame cost proportional to what was revealed rather than to the whole
-    trail. Dense enough at 2000 points per trail that this is a small fraction
-    of one frame's work.
+    Frames composite incrementally, and a halo is wider than the trail, so a
+    batch's halo spills backwards over colours already on the raster.
+    Repainting a short run behind it covers the spill while keeping the frame
+    cost proportional to what was revealed.
     """
 
     @classmethod
     def _trail_outline_sizes(cls, sizes: Any) -> Any:
         """Marker areas giving a constant-width halo around *sizes*.
 
-        Scatter sizes are areas, and a trail tapers from
-        ``_TRAIL_SIZE_START`` to ``_TRAIL_SIZE_END``, so scaling the area
-        would taper the halo along with it and leave the thin end unoutlined.
-        Growing the *radius* by a fixed amount keeps the outline even.
+        Scatter sizes are areas and the trail tapers, so scaling the area would
+        taper the halo too and leave the thin end unoutlined; growing the
+        *radius* by a fixed amount keeps it even.
         """
         import numpy as np
 
@@ -406,14 +402,11 @@ class _PlottingMixin:
         occupancy_grid = getattr(self._env, 'occupancy_grid', None)
         if occupancy_grid is not None:
             from railroad.navigation.plotting import plot_grid_background
-            # A scene image is positioned in grid cells, so it is only drawn
-            # when the plot is in that frame. It goes underneath, and the grid
-            # over it turns translucent -- an opaque obstacle fill would hide
-            # the very thing being drawn under it.
+            # Positioned in grid cells, so only drawn when the plot is in that
+            # frame. The grid over it gets out of the way.
             photo = self._render_photo_underlay(ax)
-            # The faint true-grid underlay is a stand-in for ground truth in
-            # unknown-space runs. The scene image *is* ground truth, and shown
-            # at once they muddy each other, so the image wins.
+            # The faint true-grid underlay stands in for ground truth; the image
+            # *is* ground truth, and together they muddy each other.
             true_grid = None if photo is not None else getattr(self._env, 'true_grid', None)
             plot_grid_background(
                 ax, occupancy_grid, true_grid, translucent=photo is not None,
@@ -488,19 +481,16 @@ class _PlottingMixin:
         # Draw one combined scatter for all robot trails, sorted by time
         if trail is not None:
             combined_xy, combined_sizes, combined_colors, _combined_times = trail
-            # A white halo underneath, so the trail reads against whatever it
-            # crosses -- a scene image is busy and every trail colour appears
-            # somewhere in it. Drawn as one layer below the whole trail rather
-            # than as a per-marker stroke: markers overlap, so a stroke would
-            # paint over the neighbour drawn just before it and scallop the
-            # line.
+            # A white halo, so the trail reads against a busy image. One layer
+            # below the whole trail rather than a per-marker stroke: markers
+            # overlap, and a stroke would paint over its neighbour and scallop
+            # the line.
             ax.scatter(
                 combined_xy[:, 0], combined_xy[:, 1],
                 s=self._trail_outline_sizes(combined_sizes), c="white",
                 zorder=4.5, linewidths=0,
             )
-            # Opaque, so the halo stays an outline instead of washing the
-            # colours out from behind.
+            # Opaque, or the halo washes the colours out from behind.
             ax.scatter(
                 combined_xy[:, 0], combined_xy[:, 1],
                 s=combined_sizes, c=combined_colors,
@@ -528,9 +518,8 @@ class _PlottingMixin:
             ax.autoscale()
             ax.set_aspect("equal", adjustable="datalim")
         else:
-            # Last, so everything plotted above is inside the frame: pinning
-            # the limits turns autoscale off, and a caller's coordinates need
-            # not all fall within the grid.
+            # Last, so everything above is inside the frame: pinning the
+            # limits turns autoscale off.
             self._set_grid_limits(
                 ax, occupancy_grid, photo,
                 points=None if trail is None else trail[0],
@@ -613,15 +602,11 @@ class _PlottingMixin:
     def _image_content_extent(artist: Any) -> tuple[float, float, float, float]:
         """The data-space box of an image's non-background pixels.
 
-        ProcTHOR renders its overhead view through a square orthographic camera
-        onto a white skybox, so a house that is not square arrives padded with
-        blank margin -- often a third of the frame. Framing on the padding
-        shrinks the map for nothing.
-
-        Only the *framing* uses this; the image is still drawn at its true
-        extent, so a misfire here can crop the view slightly but can never
-        misplace anything. Images with no blank border (railsim's, which is one
-        pixel per cell) return their full extent unchanged.
+        A square orthographic camera pads a non-square house with blank
+        skybox -- often a third of the frame -- and framing on that shrinks the
+        map for nothing. Only the *framing* uses this; the image still draws at
+        its true extent, so a misfire crops the view slightly and can never
+        misplace anything.
         """
         import numpy as np
 
@@ -656,19 +641,11 @@ class _PlottingMixin:
     ) -> None:
         """Frame the occupancy grid, widened to include an image and *points*.
 
-        Set explicitly rather than left to autoscale: two images whose extents
-        run in opposite directions is exactly where autoscale surprises live,
-        and framing on an image's blank margin wastes most of the panel.
-
-        Widened to the image, because the grid spans only the agent-reachable
-        bbox -- it stops a collision radius short of every wall, and in scenes
-        with a room the agent cannot enter it misses that room entirely.
-
-        Widened to *points* (the plotted trajectory and location markers)
-        because pinning the limits turns autoscale off. Without this, anything
-        a caller plots outside the grid -- location coordinates that do not all
-        fall inside it, say -- would be silently cropped, where before it
-        simply expanded the view.
+        Widened to the image because the grid spans only the agent-reachable
+        bbox: it stops a collision radius short of every wall, and misses rooms
+        the agent cannot enter entirely. Widened to *points* because pinning
+        the limits turns autoscale off, so anything a caller plots outside the
+        grid would otherwise be cropped where it used to expand the view.
         """
         import numpy as np
 
@@ -878,9 +855,8 @@ class _PlottingMixin:
 
         n_onboard = len(onboard_robots) if onboard_robots else 0
 
-        # The scene's top-down image is drawn into the main axes underneath the
-        # trajectory (see _render_photo_underlay), so there is no longer a
-        # separate overhead column. Onboard images go in a bottom row.
+        # The image goes into the main axes under the trajectory, so there is
+        # no separate overhead column. Onboard images go in a bottom row.
         fig = plt.figure(figsize=figsize)
         onboard_spec = None
         n_rows = 2 if n_onboard else 1
@@ -988,7 +964,7 @@ class _PlottingMixin:
         # Animated navigation grid background
         from railroad.navigation.plotting import (
             PHOTO_UNDERLAY_ALPHA, _BACKGROUND_GRAY, make_known_boundary_rgba,
-            make_plotting_grid, make_plotting_grid_alpha, make_plotting_grid_rgba,
+            make_plotting_grid, make_plotting_grid_rgba,
         )
 
         nav_grid_artist = None
@@ -997,14 +973,10 @@ class _PlottingMixin:
         _nav_has_true_underlay = False
         photo_artist = None
         if occupancy_grid is not None:
-            # A scene image is positioned in grid cells, so it can only be
-            # placed when the plot is in that frame -- without a grid the
-            # trajectory is drawn in whatever space location_coords uses.
-            #
-            # Drawn once beneath the animated grid, and deliberately left out of
-            # the layered/hot artist sets below: the plain canvas.draw() in
-            # _draw_chrome then bakes it into the cached chrome region, so it
-            # costs nothing per frame and returns with every restore_region().
+            # Positioned in grid cells, so only placed when the plot is in
+            # that frame. Deliberately left out of the layered/hot artist sets
+            # below, so the plain canvas.draw() in _draw_chrome bakes it into
+            # the cached chrome region and it costs nothing per frame.
             photo_artist = self._render_photo_underlay(ax)
             # As in plot_trajectories: the scene image is ground truth, so the
             # faint true-grid stand-in steps aside when one is present.
@@ -1014,18 +986,6 @@ class _PlottingMixin:
             )
             has_unknown = bool(np.any(occupancy_grid == -1.0))
             _nav_has_true_underlay = true_grid is not None and has_unknown
-
-            def _with_photo_alpha(rgb: np.ndarray, obs_grid: np.ndarray) -> np.ndarray:
-                """Attach a per-class alpha so the scene image shows through.
-
-                Returned unconditionally as RGBA when an image is present, so
-                the channel count is fixed for the whole video and ``set_data``
-                stays happy.
-                """
-                if photo_artist is None:
-                    return rgb
-                alpha = make_plotting_grid_alpha(obs_grid.T, **PHOTO_UNDERLAY_ALPHA)
-                return np.dstack([rgb, alpha])
 
             if _nav_has_true_underlay:
                 assert true_grid is not None
@@ -1037,11 +997,10 @@ class _PlottingMixin:
                 def _composite_frame(obs_grid: np.ndarray) -> np.ndarray:
                     obs_rgba = make_plotting_grid_rgba(obs_grid.T)
                     obs_alpha = obs_rgba[:, :, 3:4]
-                    rgb = underlay * (1 - obs_alpha) + obs_rgba[:, :, :3] * obs_alpha
-                    return _with_photo_alpha(rgb, obs_grid)
+                    return underlay * (1 - obs_alpha) + obs_rgba[:, :, :3] * obs_alpha
             else:
                 def _composite_frame(obs_grid: np.ndarray) -> np.ndarray:
-                    return _with_photo_alpha(make_plotting_grid(obs_grid.T), obs_grid)
+                    return make_plotting_grid(obs_grid.T)
 
             if self._nav_grid_snapshots:
                 nav_grid_frames = [
@@ -1055,6 +1014,10 @@ class _PlottingMixin:
                 nav_grid_artist = ax.imshow(
                     _composite_frame(occupancy_grid), origin="upper", zorder=0,
                 )
+            if photo_artist is not None:
+                # Set once on the artist: the grid gets out of the image's way
+                # for the whole video, so there is nothing per-frame about it.
+                nav_grid_artist.set_alpha(PHOTO_UNDERLAY_ALPHA)
 
         # Animated outline of what the robot has observed. Drawn over an image
         # only, since without one the grid itself already shows this, and it
@@ -1375,17 +1338,14 @@ class _PlottingMixin:
         def _draw_trail(lo: int, hi: int) -> None:
             """Draw trail points ``[lo, hi)``: white halo first, then colour.
 
-            Only the new points, so a frame costs what it revealed rather than
-            the whole trail. Their halo does spill backwards over colours
-            already on the raster, so the colour pass starts a little earlier
-            than the halo pass and paints that spill back in.
+            Only the new points, so a frame costs what it revealed. The colour
+            pass starts earlier than the halo pass to paint back the spill.
 
-            What the overlap does not reach is a path *crossing*: there the new
-            halo covers an older segment that is nowhere near it in time. That
-            is left alone deliberately -- it is what makes the later path read
-            as passing over the earlier one, which is the whole reason for
-            outlining a line, and redrawing every colour to avoid it would cost
-            more than the outline itself.
+            What the overlap does not reach is a path *crossing*, where the new
+            halo covers a segment far away in time. Left alone deliberately:
+            that is what makes the later path read as passing over the earlier
+            one, and repainting every colour to avoid it costs more than the
+            outline itself.
             """
             trail_outline.set_offsets(combined_xy[lo:hi])
             trail_outline.set_sizes(self._trail_outline_sizes(combined_sizes[lo:hi]))

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -373,8 +373,18 @@ class _PlottingMixin:
         occupancy_grid = getattr(self._env, 'occupancy_grid', None)
         if occupancy_grid is not None:
             from railroad.navigation.plotting import plot_grid_background
-            true_grid = getattr(self._env, 'true_grid', None)
-            plot_grid_background(ax, occupancy_grid, true_grid)
+            # A scene image is positioned in grid cells, so it is only drawn
+            # when the plot is in that frame. It goes underneath, and the grid
+            # over it turns translucent -- an opaque obstacle fill would hide
+            # the very thing being drawn under it.
+            photo = self._render_photo_underlay(ax)
+            # The faint true-grid underlay is a stand-in for ground truth in
+            # unknown-space runs. The scene image *is* ground truth, and shown
+            # at once they muddy each other, so the image wins.
+            true_grid = None if photo is not None else getattr(self._env, 'true_grid', None)
+            plot_grid_background(
+                ax, occupancy_grid, true_grid, translucent=photo is not None,
+            )
             # Predicted frontier probabilities (LSP environments): color
             # each frontier's cells by its prob_feasible.
             overlays = getattr(self._env, 'frontier_probability_overlays', None)
@@ -384,6 +394,8 @@ class _PlottingMixin:
                     make_frontier_overlay_rgba(occupancy_grid.shape, overlays),
                     origin="upper", zorder=1,
                 )
+        else:
+            photo = None
 
         if self._goal_time is not None:
             t_end = self._goal_time
@@ -461,6 +473,14 @@ class _PlottingMixin:
         if occupancy_grid is None:
             ax.autoscale()
             ax.set_aspect("equal", adjustable="datalim")
+        else:
+            # Last, so everything plotted above is inside the frame: pinning
+            # the limits turns autoscale off, and a caller's coordinates need
+            # not all fall within the grid.
+            self._set_grid_limits(
+                ax, occupancy_grid, photo,
+                points=None if trail is None else trail[0],
+            )
 
         ax.set_title(f"Entity Trajectories  (cost = {t_end:.1f})",
                      fontfamily="monospace", fontsize=10)
@@ -513,24 +533,105 @@ class _PlottingMixin:
 
         return result
 
-    def _render_overhead(self: PlannerDashboard, ax: Any) -> bool:
-        """Render ProcTHOR top-down image on the given axes if available.
+    def _render_photo_underlay(self: PlannerDashboard, ax: Any) -> Any | None:
+        """Draw the scene's aligned top-down image as the bottom layer of *ax*.
 
-        Args:
-            ax: Matplotlib axes to draw on.
-
-        Returns:
-            True if an overhead image was rendered, False otherwise.
+        Returns the ``AxesImage``, or ``None`` when the scene cannot place an
+        image on the occupancy grid -- no ProcTHOR/railsim scene, or a ProcTHOR
+        cache predating the recorded camera extent. A scene offering only the
+        older, unpositioned ``get_top_down_image`` deliberately gets nothing:
+        an image that cannot be located can only be drawn misaligned.
         """
         scene = getattr(self._env, "scene", None)
-        get_top_down = getattr(scene, "get_top_down_image", None)
-        if get_top_down is None:
-            return False
-        top_down_image = get_top_down(orthographic=True)
-        ax.imshow(top_down_image)
-        ax.axis("off")
-        ax.set_title("Top-down View", fontsize=8)
-        return True
+        get_view = getattr(scene, "get_top_down_view", None)
+        if get_view is None:
+            return None
+        view = get_view()
+        if view is None:
+            return None
+        # zorder -1 sits below the grid (0) without disturbing the frontier
+        # overlay (1), location markers (4) or the trail (5).
+        return ax.imshow(
+            view.image, origin="upper", extent=view.extent, zorder=-1,
+        )
+
+    @staticmethod
+    def _image_content_extent(artist: Any) -> tuple[float, float, float, float]:
+        """The data-space box of an image's non-background pixels.
+
+        ProcTHOR renders its overhead view through a square orthographic camera
+        onto a white skybox, so a house that is not square arrives padded with
+        blank margin -- often a third of the frame. Framing on the padding
+        shrinks the map for nothing.
+
+        Only the *framing* uses this; the image is still drawn at its true
+        extent, so a misfire here can crop the view slightly but can never
+        misplace anything. Images with no blank border (railsim's, which is one
+        pixel per cell) return their full extent unchanged.
+        """
+        import numpy as np
+
+        left, right, bottom, top = artist.get_extent()
+        data = np.asarray(artist.get_array())
+        if data.ndim != 3 or data.shape[2] < 3:
+            return left, right, bottom, top
+        rgb = data[:, :, :3]
+        white = 250 if np.issubdtype(rgb.dtype, np.integer) else 250 / 255
+        content = np.any(rgb < white, axis=2)
+        rows = np.flatnonzero(np.any(content, axis=1))
+        cols = np.flatnonzero(np.any(content, axis=0))
+        if rows.size == 0 or cols.size == 0:
+            return left, right, bottom, top
+
+        height, width = content.shape
+        # Pixel index -> data coordinate, over the image's own extent. Row 0
+        # sits at `top`, matching the origin="upper" it was drawn with.
+        def _lerp(lo, hi, index, count):
+            return lo + (hi - lo) * (index / count)
+
+        return (
+            _lerp(left, right, cols[0], width),
+            _lerp(left, right, cols[-1] + 1, width),
+            _lerp(top, bottom, rows[-1] + 1, height),
+            _lerp(top, bottom, rows[0], height),
+        )
+
+    def _set_grid_limits(
+        self: PlannerDashboard, ax: Any, occupancy_grid: Any, photo: Any | None,
+        points: Any = None,
+    ) -> None:
+        """Frame the occupancy grid, widened to include an image and *points*.
+
+        Set explicitly rather than left to autoscale: two images whose extents
+        run in opposite directions is exactly where autoscale surprises live,
+        and framing on an image's blank margin wastes most of the panel.
+
+        Widened to the image, because the grid spans only the agent-reachable
+        bbox -- it stops a collision radius short of every wall, and in scenes
+        with a room the agent cannot enter it misses that room entirely.
+
+        Widened to *points* (the plotted trajectory and location markers)
+        because pinning the limits turns autoscale off. Without this, anything
+        a caller plots outside the grid -- location coordinates that do not all
+        fall inside it, say -- would be silently cropped, where before it
+        simply expanded the view.
+        """
+        import numpy as np
+
+        n_x, n_y = occupancy_grid.shape
+        left, right, bottom, top = -0.5, n_x - 0.5, n_y - 0.5, -0.5
+        if photo is not None:
+            p_left, p_right, p_bottom, p_top = self._image_content_extent(photo)
+            left, right = min(left, p_left), max(right, p_right)
+            top, bottom = min(top, p_top), max(bottom, p_bottom)
+        if points is not None:
+            xy = np.asarray(points, dtype=float).reshape(-1, 2)
+            if xy.size:
+                left, right = min(left, xy[:, 0].min()), max(right, xy[:, 0].max())
+                top, bottom = min(top, xy[:, 1].min()), max(bottom, xy[:, 1].max())
+        ax.set_xlim(left, right)
+        ax.set_ylim(bottom, top)  # bottom > top: y increases downward
+        ax.set_aspect("equal", adjustable="box")
 
     def _render_sidebar(
         self: PlannerDashboard,
@@ -695,7 +796,7 @@ class _PlottingMixin:
         location_coords: dict[str, tuple[float, float]] | None = None,
         onboard_robots: list[str] | None = None,
     ) -> tuple[Any, Any, Any, Any, Any, float, dict[str, Any]] | None:
-        """Create a GridSpec figure with main + sidebar + optional overhead axes.
+        """Create a GridSpec figure with main + sidebar axes.
 
         When ``onboard_robots`` is given, a bottom row is added with one axes
         per robot for onboard camera imagery.
@@ -721,57 +822,31 @@ class _PlottingMixin:
         if t_end <= 0.0:
             return None
 
-        has_overhead = getattr(getattr(self._env, "scene", None), "get_top_down_image", None) is not None
         n_onboard = len(onboard_robots) if onboard_robots else 0
 
+        # The scene's top-down image is drawn into the main axes underneath the
+        # trajectory (see _render_photo_underlay), so there is no longer a
+        # separate overhead column. Onboard images go in a bottom row.
         fig = plt.figure(figsize=figsize)
         onboard_spec = None
-        onboard_stacked = False
-        if has_overhead:
-            if n_onboard:
-                # Onboard images stack in the left column, under the
-                # top-down view; main plot and sidebar span both rows.
-                gs = GridSpec(2, 3, width_ratios=[1, 2, 1],
-                             height_ratios=[3, n_onboard], figure=fig,
-                             wspace=0.1, left=0.03, right=0.97, top=0.95, bottom=0.05)
-                overhead_ax = fig.add_subplot(gs[0, 0])
-                main_ax = fig.add_subplot(gs[:, 1])
-                sidebar_ax = fig.add_subplot(gs[:, 2])
-                onboard_spec = gs[1, 0]
-                onboard_stacked = True
-            else:
-                gs = GridSpec(1, 3, width_ratios=[1, 2, 1], figure=fig,
-                             wspace=0.1, left=0.03, right=0.97, top=0.95, bottom=0.05)
-                overhead_ax = fig.add_subplot(gs[0, 0])
-                main_ax = fig.add_subplot(gs[0, 1])
-                sidebar_ax = fig.add_subplot(gs[0, 2])
-            self._render_overhead(overhead_ax)
-        else:
-            # No top-down view: onboard images go in a bottom row instead.
-            n_rows = 2 if n_onboard else 1
-            height_ratios = [3, 1] if n_onboard else None
-            gs = GridSpec(n_rows, 2, width_ratios=[3, 1], height_ratios=height_ratios,
-                         figure=fig,
-                         wspace=0.1, left=0.05, right=0.97, top=0.95, bottom=0.05)
-            main_ax = fig.add_subplot(gs[0, 0])
-            sidebar_ax = fig.add_subplot(gs[0, 1])
-            if n_onboard:
-                onboard_spec = gs[1, :]
+        n_rows = 2 if n_onboard else 1
+        height_ratios = [3, 1] if n_onboard else None
+        gs = GridSpec(n_rows, 2, width_ratios=[3, 1], height_ratios=height_ratios,
+                     figure=fig,
+                     wspace=0.1, left=0.05, right=0.97, top=0.95, bottom=0.05)
+        main_ax = fig.add_subplot(gs[0, 0])
+        sidebar_ax = fig.add_subplot(gs[0, 1])
+        if n_onboard:
+            onboard_spec = gs[1, :]
         sidebar_ax.set_axis_off()
 
         onboard_axes: dict[str, Any] = {}
         if onboard_robots and onboard_spec is not None:
-            if onboard_stacked:
-                onboard_gs = GridSpecFromSubplotSpec(
-                    n_onboard, 1, subplot_spec=onboard_spec, hspace=0.25,
-                )
-            else:
-                onboard_gs = GridSpecFromSubplotSpec(
-                    1, n_onboard, subplot_spec=onboard_spec, wspace=0.05,
-                )
+            onboard_gs = GridSpecFromSubplotSpec(
+                1, n_onboard, subplot_spec=onboard_spec, wspace=0.05,
+            )
             for i, robot in enumerate(onboard_robots):
-                index = (i, 0) if onboard_stacked else (0, i)
-                onboard_ax = fig.add_subplot(onboard_gs[index])
+                onboard_ax = fig.add_subplot(onboard_gs[0, i])
                 onboard_ax.set_axis_off()
                 onboard_axes[robot] = onboard_ax
 
@@ -857,16 +932,46 @@ class _PlottingMixin:
             onboard_frame_idx[robot] = 0
 
         # Animated navigation grid background
-        from railroad.navigation.plotting import make_plotting_grid, make_plotting_grid_rgba, _BACKGROUND_GRAY
+        from railroad.navigation.plotting import (
+            PHOTO_UNDERLAY_ALPHA, _BACKGROUND_GRAY, make_plotting_grid,
+            make_plotting_grid_alpha, make_plotting_grid_rgba,
+        )
 
         nav_grid_artist = None
         nav_grid_frames: list[tuple[float, Any]] = []
         occupancy_grid = getattr(self._env, 'occupancy_grid', None)
         _nav_has_true_underlay = False
+        photo_artist = None
         if occupancy_grid is not None:
-            true_grid = getattr(self._env, "true_grid", None)
+            # A scene image is positioned in grid cells, so it can only be
+            # placed when the plot is in that frame -- without a grid the
+            # trajectory is drawn in whatever space location_coords uses.
+            #
+            # Drawn once beneath the animated grid, and deliberately left out of
+            # the layered/hot artist sets below: the plain canvas.draw() in
+            # _draw_chrome then bakes it into the cached chrome region, so it
+            # costs nothing per frame and returns with every restore_region().
+            photo_artist = self._render_photo_underlay(ax)
+            # As in plot_trajectories: the scene image is ground truth, so the
+            # faint true-grid stand-in steps aside when one is present.
+            true_grid = (
+                None if photo_artist is not None
+                else getattr(self._env, "true_grid", None)
+            )
             has_unknown = bool(np.any(occupancy_grid == -1.0))
             _nav_has_true_underlay = true_grid is not None and has_unknown
+
+            def _with_photo_alpha(rgb: np.ndarray, obs_grid: np.ndarray) -> np.ndarray:
+                """Attach a per-class alpha so the scene image shows through.
+
+                Returned unconditionally as RGBA when an image is present, so
+                the channel count is fixed for the whole video and ``set_data``
+                stays happy.
+                """
+                if photo_artist is None:
+                    return rgb
+                alpha = make_plotting_grid_alpha(obs_grid.T, **PHOTO_UNDERLAY_ALPHA)
+                return np.dstack([rgb, alpha])
 
             if _nav_has_true_underlay:
                 assert true_grid is not None
@@ -878,10 +983,11 @@ class _PlottingMixin:
                 def _composite_frame(obs_grid: np.ndarray) -> np.ndarray:
                     obs_rgba = make_plotting_grid_rgba(obs_grid.T)
                     obs_alpha = obs_rgba[:, :, 3:4]
-                    return underlay * (1 - obs_alpha) + obs_rgba[:, :, :3] * obs_alpha
+                    rgb = underlay * (1 - obs_alpha) + obs_rgba[:, :, :3] * obs_alpha
+                    return _with_photo_alpha(rgb, obs_grid)
             else:
                 def _composite_frame(obs_grid: np.ndarray) -> np.ndarray:
-                    return make_plotting_grid(obs_grid.T)
+                    return _with_photo_alpha(make_plotting_grid(obs_grid.T), obs_grid)
 
             if self._nav_grid_snapshots:
                 nav_grid_frames = [
@@ -909,13 +1015,6 @@ class _PlottingMixin:
                 frontier_overlay_frames[0][1], origin="upper", zorder=1,
             )
 
-        n_frames = int(fps * duration)
-        animation_times = np.linspace(0.0, t_end, n_frames)
-        # Prepend the final time as frame 0 so the video thumbnail/poster
-        # shows the completed plan rather than the empty initial state.
-        frame_times = np.concatenate(([t_end], animation_times))
-        n_frames += 1
-
         # Pre-compute trail arrays (dense scatter data for all robots)
         trail = self._compute_trail_arrays(trajectories, t_end)
         if trail is not None:
@@ -925,6 +1024,21 @@ class _PlottingMixin:
             combined_sizes = np.empty(0)
             combined_colors = np.empty((0, 4))
             combined_times = np.empty(0)
+
+        if occupancy_grid is not None:
+            # Before label_offset below, which reads ax.get_ylim(). The trail is
+            # computed above so the frame can include a path that leaves the
+            # grid: pinning the limits turns autoscale off.
+            self._set_grid_limits(
+                ax, occupancy_grid, photo_artist, points=combined_xy,
+            )
+
+        n_frames = int(fps * duration)
+        animation_times = np.linspace(0.0, t_end, n_frames)
+        # Prepend the final time as frame 0 so the video thumbnail/poster
+        # shows the completed plan rather than the empty initial state.
+        frame_times = np.concatenate(([t_end], animation_times))
+        n_frames += 1
 
         # Derive entity names from trajectories (robots with >= 2 waypoints)
         entity_names = sorted(

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -439,6 +439,12 @@ class _PlottingMixin:
                 if traj_times:
                     t_end = max(t_end, max(traj_times))
         trail = self._compute_trail_arrays(trajectories, t_end)
+        # Everything drawn in data coordinates, gathered for the frame below:
+        # pinning the limits turns autoscale off, so anything left out is
+        # cropped rather than expanding the view.
+        plotted_points: list[tuple[float, float]] = []
+        if trail is not None:
+            plotted_points.extend(map(tuple, trail[0]))
 
         # Plot robot location markers and labels
         for entity in sorted(self.known_robots & set(trajectories.keys())):
@@ -464,6 +470,7 @@ class _PlottingMixin:
 
             wx = [c[0] for _, c in annotated_locs]
             wy = [c[1] for _, c in annotated_locs]
+            plotted_points.extend(zip(wx, wy))
             ax.scatter(wx, wy, s=20, zorder=6, color="black")
 
             ax.annotate(
@@ -507,6 +514,7 @@ class _PlottingMixin:
 
                 x = [p[0] for p in waypoints]
                 y = [p[1] for p in waypoints]
+                plotted_points.extend(zip(x, y))
                 ax.plot(x, y, linestyle="--", linewidth=1, alpha=0.6, label=entity)
                 ax.scatter(x, y, s=10, zorder=5, alpha=0.6)
 
@@ -520,10 +528,7 @@ class _PlottingMixin:
         else:
             # Last, so everything above is inside the frame: pinning the
             # limits turns autoscale off.
-            self._set_grid_limits(
-                ax, occupancy_grid, photo,
-                points=None if trail is None else trail[0],
-            )
+            self._set_grid_limits(ax, occupancy_grid, photo, points=plotted_points)
 
         ax.set_title(f"Entity Trajectories  (cost = {t_end:.1f})",
                      fontfamily="monospace", fontsize=10)
@@ -1060,11 +1065,21 @@ class _PlottingMixin:
             combined_times = np.empty(0)
 
         if occupancy_grid is not None:
-            # Before label_offset below, which reads ax.get_ylim(). The trail is
-            # computed above so the frame can include a path that leaves the
-            # grid: pinning the limits turns autoscale off.
+            # Before label_offset below, which reads ax.get_ylim(). Pinning the
+            # limits turns autoscale off, so everything drawn in data
+            # coordinates has to be gathered first -- the trail, and the
+            # location markers placed further down, whose coordinates a caller
+            # supplies and need not fall inside the grid.
+            marker_coords = [
+                stored if stored is not None else env_coords.get(name)
+                for positions in self._entity_positions.values()
+                for _time, name, stored in positions
+                if not name.startswith("frontier_")
+            ]
             self._set_grid_limits(
-                ax, occupancy_grid, photo_artist, points=combined_xy,
+                ax, occupancy_grid, photo_artist,
+                points=[*map(tuple, combined_xy),
+                        *(c for c in marker_coords if c is not None)],
             )
 
         n_frames = int(fps * duration)

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -418,6 +418,14 @@ class _PlottingMixin:
             plot_grid_background(
                 ax, occupancy_grid, true_grid, translucent=photo is not None,
             )
+            if photo is not None:
+                # The image renders ground truth everywhere, including where
+                # the robot has not looked, so outline how far it has seen.
+                from railroad.navigation.plotting import make_known_boundary_rgba
+                ax.imshow(
+                    make_known_boundary_rgba(occupancy_grid),
+                    origin="upper", zorder=0.5,
+                )
             # Predicted frontier probabilities (LSP environments): color
             # each frontier's cells by its prob_feasible.
             overlays = getattr(self._env, 'frontier_probability_overlays', None)
@@ -979,8 +987,8 @@ class _PlottingMixin:
 
         # Animated navigation grid background
         from railroad.navigation.plotting import (
-            PHOTO_UNDERLAY_ALPHA, _BACKGROUND_GRAY, make_plotting_grid,
-            make_plotting_grid_alpha, make_plotting_grid_rgba,
+            PHOTO_UNDERLAY_ALPHA, _BACKGROUND_GRAY, make_known_boundary_rgba,
+            make_plotting_grid, make_plotting_grid_alpha, make_plotting_grid_rgba,
         )
 
         nav_grid_artist = None
@@ -1047,6 +1055,23 @@ class _PlottingMixin:
                 nav_grid_artist = ax.imshow(
                     _composite_frame(occupancy_grid), origin="upper", zorder=0,
                 )
+
+        # Animated outline of what the robot has observed. Drawn over an image
+        # only, since without one the grid itself already shows this, and it
+        # follows the same snapshots as the grid so the outline matches the
+        # frame rather than the final state.
+        known_boundary_artist = None
+        known_boundary_frames: list[tuple[float, Any]] = []
+        if occupancy_grid is not None and photo_artist is not None:
+            if self._nav_grid_snapshots:
+                known_boundary_frames = [
+                    (t, make_known_boundary_rgba(g))
+                    for t, g in self._nav_grid_snapshots
+                ]
+                first = known_boundary_frames[0][1]
+            else:
+                first = make_known_boundary_rgba(occupancy_grid)
+            known_boundary_artist = ax.imshow(first, origin="upper", zorder=0.5)
 
         # Animated frontier-probability overlay (LSP environments)
         frontier_overlay_artist = None
@@ -1201,7 +1226,7 @@ class _PlottingMixin:
 
         # Which snapshot each image artist is currently holding, so repeated
         # frames do not re-push identical data.
-        shown_idx = {"nav": -1, "overlay": -1}
+        shown_idx = {"nav": -1, "overlay": -1, "boundary": -1}
 
         def _apply_frame(frame: int) -> tuple[tuple, tuple, tuple, int]:
             """Point every artist at its state for *frame*.
@@ -1222,6 +1247,11 @@ class _PlottingMixin:
                 if nav_idx != shown_idx["nav"]:
                     nav_grid_artist.set_data(nav_grid_frames[nav_idx][1])
                     shown_idx["nav"] = nav_idx
+                # Same snapshots, so the same index keeps the outline in step.
+                if (known_boundary_artist is not None and known_boundary_frames
+                        and nav_idx != shown_idx["boundary"]):
+                    known_boundary_artist.set_data(known_boundary_frames[nav_idx][1])
+                    shown_idx["boundary"] = nav_idx
             # Frontier-probability overlay
             overlay_idx = -1
             if frontier_overlay_artist is not None and overlay_times is not None:
@@ -1293,7 +1323,8 @@ class _PlottingMixin:
         hot_artists.sort(key=lambda a: a.get_zorder())
 
         stack_artists: list[Any] = [
-            a for a in (nav_grid_artist, frontier_overlay_artist) if a is not None
+            a for a in (nav_grid_artist, known_boundary_artist,
+                        frontier_overlay_artist) if a is not None
         ]
         if stack_artists:
             # The grid images cover the whole data area, and a real draw puts

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -416,11 +416,12 @@ class _PlottingMixin:
                     make_known_boundary_rgba, make_untraversable_shade_rgba,
                 )
                 # An image shows the room, not the map: darken what the robot
-                # cannot stand on so the space it can move through reads.
-                ax.imshow(
-                    make_untraversable_shade_rgba(occupancy_grid),
-                    origin="upper", zorder=0.25,
+                # cannot stand on so the space it can move through reads. Out
+                # to the image, which reaches past the mapped area.
+                shade, shade_extent = make_untraversable_shade_rgba(
+                    occupancy_grid, self._image_content_extent(photo),
                 )
+                ax.imshow(shade, origin="upper", extent=shade_extent, zorder=0.25)
                 # The image renders ground truth everywhere, including where
                 # the robot has not looked, so outline how far it has seen.
                 ax.imshow(
@@ -537,6 +538,7 @@ class _PlottingMixin:
             # Last, so everything above is inside the frame: pinning the
             # limits turns autoscale off.
             self._set_grid_limits(ax, occupancy_grid, photo, points=plotted_points)
+            self._label_axes_in_meters(ax)
 
         ax.set_title(f"Entity Trajectories  (cost = {t_end:.1f})",
                      fontfamily="monospace", fontsize=10)
@@ -647,6 +649,25 @@ class _PlottingMixin:
             _lerp(top, bottom, rows[-1] + 1, height),
             _lerp(top, bottom, rows[0], height),
         )
+
+    def _label_axes_in_meters(self: PlannerDashboard, ax: Any) -> None:
+        """Show metres on the axes when the scene knows its cell size.
+
+        The data stays in grid cells -- trajectories, extents and overlays all
+        share that frame -- so only the tick labels are converted. Scenes that
+        do not report a resolution keep cell numbering.
+        """
+        from matplotlib.ticker import FuncFormatter
+
+        resolution = getattr(getattr(self._env, "scene", None), "resolution", None)
+        if not resolution:
+            return
+        for axis, name in ((ax.xaxis, "x"), (ax.yaxis, "y")):
+            axis.set_major_formatter(
+                FuncFormatter(lambda cells, _pos: f"{cells * resolution:g}")
+            )
+        ax.set_xlabel("x (m)", fontsize=8)
+        ax.set_ylabel("y (m)", fontsize=8)
 
     def _set_grid_limits(
         self: PlannerDashboard, ax: Any, occupancy_grid: Any, photo: Any | None,
@@ -1042,11 +1063,19 @@ class _PlottingMixin:
         shade_artist = None
         shade_frames: list[tuple[float, Any]] = []
         if occupancy_grid is not None and photo_artist is not None:
-            for make, zorder in ((make_untraversable_shade_rgba, 0.25),
-                                 (make_known_boundary_rgba, 0.5)):
+            cover = self._image_content_extent(photo_artist)
+            _, shade_extent = make_untraversable_shade_rgba(occupancy_grid, cover)
+
+            def _shade(grid):
+                return make_untraversable_shade_rgba(grid, cover)[0]
+
+            for make, zorder, extent in ((_shade, 0.25, shade_extent),
+                                         (make_known_boundary_rgba, 0.5, None)):
                 frames = [(t, make(g)) for t, g in self._nav_grid_snapshots]
                 first = frames[0][1] if frames else make(occupancy_grid)
-                artist = ax.imshow(first, origin="upper", zorder=zorder)
+                artist = ax.imshow(
+                    first, origin="upper", zorder=zorder, extent=extent,
+                )
                 if zorder == 0.25:
                     shade_artist, shade_frames = artist, frames
                 else:
@@ -1092,6 +1121,7 @@ class _PlottingMixin:
                 points=[*map(tuple, combined_xy),
                         *(c for c in marker_coords if c is not None)],
             )
+            self._label_axes_in_meters(ax)
 
         n_frames = int(fps * duration)
         animation_times = np.linspace(0.0, t_end, n_frames)

--- a/packages/railroad/src/railroad/environment/__init__.py
+++ b/packages/railroad/src/railroad/environment/__init__.py
@@ -23,7 +23,7 @@ Unknown-space frontier search lives in railroad.experimental.unknown_search.
 
 from .environment import ActiveSkill, Environment
 from .skill import InterruptibleNavigationMoveSkill, MotionSkill, NavigationMoveSkill
-from .types import Pose, PoseLike
+from .types import Pose, PoseLike, TopDownView
 from .symbolic import (
     LocationRegistry,
     SymbolicEnvironment,
@@ -44,4 +44,5 @@ __all__ = [
     "PoseLike",
     "SymbolicEnvironment",
     "SymbolicSkill",
+    "TopDownView",
 ]

--- a/packages/railroad/src/railroad/environment/procthor/_display.py
+++ b/packages/railroad/src/railroad/environment/procthor/_display.py
@@ -1,0 +1,71 @@
+"""Making a headless X screen big enough for AI2-THOR to render into.
+
+AI2-THOR's Linux64 platform refuses a render larger than the X screen, and an
+X server with no outputs connected defaults to 1024x768 whatever the GPU can
+do -- so asking for a 2048 top-down image fails before Unity starts. The screen
+can simply be grown, since ``xrandr`` reports a maximum in the tens of
+thousands; it just needs asking.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+_CURRENT = re.compile(r"current\s+(\d+)\s*x\s*(\d+)")
+
+
+def _screen_size() -> Optional[tuple[int, int]]:
+    """Current X screen size, or None if it cannot be asked for."""
+    if not os.environ.get("DISPLAY") or not shutil.which("xrandr"):
+        return None
+    try:
+        out = subprocess.run(
+            ["xrandr"], capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    # Never resize a screen someone is looking at: with a monitor attached,
+    # growing the framebuffer turns the desktop into a panning viewport.
+    if re.search(r"^\S+ connected", out.stdout, re.MULTILINE):
+        return None
+    found = _CURRENT.search(out.stdout)
+    return (int(found.group(1)), int(found.group(2))) if found else None
+
+
+def _resize(width: int, height: int) -> bool:
+    try:
+        return subprocess.run(
+            ["xrandr", "--fb", f"{width}x{height}"],
+            capture_output=True, timeout=10,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+@contextmanager
+def screen_at_least(width: int, height: int) -> Iterator[bool]:
+    """Grow a headless X screen to fit *width* x *height*, then put it back.
+
+    Yields whether it was grown. Does nothing -- and reports nothing -- when
+    there is no display, no ``xrandr``, a monitor is connected, or the screen
+    is already big enough; AI2-THOR then fails with its own clear message
+    rather than this masking the cause.
+    """
+    original = _screen_size()
+    grew = bool(
+        original
+        and (original[0] < width or original[1] < height)
+        and _resize(max(width, original[0]), max(height, original[1]))
+    )
+    try:
+        yield grew
+    finally:
+        if grew and original is not None:
+            _resize(*original)

--- a/packages/railroad/src/railroad/environment/procthor/_display.py
+++ b/packages/railroad/src/railroad/environment/procthor/_display.py
@@ -9,6 +9,7 @@ thousands; it just needs asking.
 
 from __future__ import annotations
 
+import glob
 import os
 import re
 import shutil
@@ -19,34 +20,45 @@ from typing import Iterator, Optional
 _CURRENT = re.compile(r"current\s+(\d+)\s*x\s*(\d+)")
 
 
-def _screen_size() -> Optional[tuple[int, int]]:
-    """Current X screen size, or None if it cannot be asked for."""
-    if not os.environ.get("DISPLAY") or not shutil.which("xrandr"):
+def _candidate_displays() -> list[str]:
+    """Displays to consider, the way AI2-THOR finds them.
+
+    It globs the socket directory rather than reading ``DISPLAY``, so an unset
+    variable is no reason to skip: it will still find and use ``:0``.
+    """
+    if os.environ.get("DISPLAY"):
+        return [os.environ["DISPLAY"]]
+    return sorted(
+        ":" + os.path.basename(socket)[1:]
+        for socket in glob.glob("/tmp/.X11-unix/X[0-9]*")
+    )
+
+
+def _xrandr(display: str, *args: str) -> Optional[str]:
+    if not shutil.which("xrandr"):
         return None
     try:
-        out = subprocess.run(
-            ["xrandr"], capture_output=True, text=True, timeout=10,
+        done = subprocess.run(
+            ["xrandr", "-d", display, *args],
+            capture_output=True, text=True, timeout=10,
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    if out.returncode != 0:
-        return None
+    return done.stdout if done.returncode == 0 else None
+
+
+def _growable(display: str, width: int, height: int) -> Optional[tuple[int, int]]:
+    """The screen's size, if it is smaller than asked for and safe to resize."""
+    listing = _xrandr(display)
     # Never resize a screen someone is looking at: with a monitor attached,
     # growing the framebuffer turns the desktop into a panning viewport.
-    if re.search(r"^\S+ connected", out.stdout, re.MULTILINE):
+    if listing is None or re.search(r"^\S+ connected", listing, re.MULTILINE):
         return None
-    found = _CURRENT.search(out.stdout)
-    return (int(found.group(1)), int(found.group(2))) if found else None
-
-
-def _resize(width: int, height: int) -> bool:
-    try:
-        return subprocess.run(
-            ["xrandr", "--fb", f"{width}x{height}"],
-            capture_output=True, timeout=10,
-        ).returncode == 0
-    except (OSError, subprocess.SubprocessError):
-        return False
+    found = _CURRENT.search(listing)
+    if not found:
+        return None
+    current = (int(found.group(1)), int(found.group(2)))
+    return current if current[0] < width or current[1] < height else None
 
 
 @contextmanager
@@ -58,14 +70,17 @@ def screen_at_least(width: int, height: int) -> Iterator[bool]:
     is already big enough; AI2-THOR then fails with its own clear message
     rather than this masking the cause.
     """
-    original = _screen_size()
-    grew = bool(
-        original
-        and (original[0] < width or original[1] < height)
-        and _resize(max(width, original[0]), max(height, original[1]))
-    )
+    grown: Optional[tuple[str, tuple[int, int]]] = None
+    for display in _candidate_displays():
+        current = _growable(display, width, height)
+        if current and _xrandr(
+            display, "--fb",
+            f"{max(width, current[0])}x{max(height, current[1])}",
+        ) is not None:
+            grown = (display, current)
+            break
     try:
-        yield grew
+        yield grown is not None
     finally:
-        if grew and original is not None:
-            _resize(*original)
+        if grown is not None:
+            _xrandr(grown[0], "--fb", f"{grown[1][0]}x{grown[1][1]}")

--- a/packages/railroad/src/railroad/environment/procthor/_scene_lock.py
+++ b/packages/railroad/src/railroad/environment/procthor/_scene_lock.py
@@ -53,10 +53,11 @@ def scene_generation_lock(
         yield False
         return
 
-    target = path or lock_path()
     deadline = time.monotonic() + (DEFAULT_TIMEOUT if timeout is None else timeout)
 
     try:
+        # lock_path() creates the resources directory, so it fails open too.
+        target = path or lock_path()
         target.parent.mkdir(parents=True, exist_ok=True)
         handle = open(target, "a+")
     except OSError:

--- a/packages/railroad/src/railroad/environment/procthor/_scene_lock.py
+++ b/packages/railroad/src/railroad/environment/procthor/_scene_lock.py
@@ -42,9 +42,10 @@ def scene_generation_lock(
     """Hold the exclusive scene-generation lock for the duration of the block.
 
     Yields True when the lock was held, False when it could not be taken (no
-    ``fcntl`` on this platform, an unwritable directory, or the timeout
-    elapsed). Failing open is deliberate: a locking problem should slow a
-    machine down, not stop a run that would otherwise have worked.
+    ``fcntl`` on this platform, an unwritable directory, a filesystem that
+    cannot lock, or the timeout elapsed). Failing open is deliberate: a locking
+    problem should slow a machine down, not stop a run that would otherwise
+    have worked.
     """
     try:
         import fcntl
@@ -68,7 +69,8 @@ def scene_generation_lock(
             try:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 break
-            except OSError:
+            except BlockingIOError:
+                # Someone else holds it. This is the case worth waiting out.
                 if time.monotonic() >= deadline:
                     yield False
                     return
@@ -77,6 +79,18 @@ def scene_generation_lock(
                           "generating a scene...")
                     announced = True
                 time.sleep(POLL_SECONDS)
+            except OSError as error:
+                # Anything else means flock will never succeed here, not that
+                # it is busy: ENOLCK, EOPNOTSUPP, or EINVAL on NFS without
+                # lockd, on CIFS, and on some container overlay filesystems.
+                # Retrying would poll for the whole timeout -- half an hour by
+                # default -- while claiming to wait on another process. That is
+                # a live path precisely because PROCTHOR_RESOURCES_DIR exists
+                # to put the cache somewhere shared.
+                print(f"[procthor] cannot lock {target} ({error.strerror}); "
+                      "generating without serialising across processes")
+                yield False
+                return
         try:
             yield True
         finally:

--- a/packages/railroad/src/railroad/environment/procthor/scene.py
+++ b/packages/railroad/src/railroad/environment/procthor/scene.py
@@ -1,9 +1,12 @@
 """ProcTHOR scene data provider."""
 
+from __future__ import annotations
+
 from typing import Callable, Dict, Set, Tuple
 
 import numpy as np
 
+from railroad.environment.types import TopDownView
 from .thor_interface import ThorInterface
 
 
@@ -137,3 +140,7 @@ class ProcTHORScene:
     def get_top_down_image(self, orthographic: bool = True) -> np.ndarray:
         """Get top-down view image of the scene."""
         return self._thor.get_top_down_image(orthographic=orthographic)
+
+    def get_top_down_view(self) -> TopDownView | None:
+        """Top-down image aligned to :attr:`grid`, or ``None`` if unavailable."""
+        return self._thor.get_top_down_view()

--- a/packages/railroad/src/railroad/environment/procthor/scene.py
+++ b/packages/railroad/src/railroad/environment/procthor/scene.py
@@ -47,6 +47,11 @@ class ProcTHORScene:
         return self._thor.occupancy_grid
 
     @property
+    def resolution(self) -> float:
+        """Meters per grid cell."""
+        return float(self._thor.grid_resolution)
+
+    @property
     def scene_graph(self):
         """Scene graph for visualization/debugging."""
         return self._thor.scene_graph

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -192,6 +192,13 @@ class ThorInterface:
         try:
             with os.fdopen(handle, 'wb') as file:
                 pickle.dump(cache, file)
+            # mkstemp is 0600, where the plain open() this replaced took the
+            # umask default. PROCTHOR_RESOURCES_DIR exists to put this cache
+            # somewhere shared, and a 0600 entry there is unreadable to the
+            # next user -- who then regenerates it, launching Unity, every run.
+            umask = os.umask(0o777)
+            os.umask(umask)
+            os.chmod(temp_name, 0o666 & ~umask)
             os.replace(temp_name, target)
         except BaseException:  # including KeyboardInterrupt, the likely one
             Path(temp_name).unlink(missing_ok=True)

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -40,12 +40,16 @@ cached scene; raw-array images from either older version still load.
 _MAP_VIEW_ROTATION = {"x": 90.0, "y": 0.0, "z": 0.0}
 """Straight down, with camera-right along world +x and camera-up along +z."""
 
-TOP_DOWN_RENDER_PX = 2048
+TOP_DOWN_RENDER_PX = int(os.environ.get("PROCTHOR_TOP_DOWN_PX", 2048))
 """Square render size for the cached top-down images.
 
 Saved plots are dpi=300, which puts ~2000 pixels across the map axes; at the
 old 480 the image was upscaled about four times. Costs generation only -- the
 controller is stopped as soon as the cache is written.
+
+AI2-THOR's Linux64 platform refuses a render larger than the X display, and a
+headless screen defaults to 1024x768; ``_display.screen_at_least`` grows it for
+the duration. Lower this if that is not possible.
 """
 
 JPEG_QUALITY = 75
@@ -133,18 +137,22 @@ class ThorInterface:
                 self.cached_data = self._load_cache() if use_cache else None
                 if self.cached_data is None:
                     from ai2thor.controller import Controller
-                    self.controller = Controller(
-                        scene=self.scene,
-                        gridSize=self.grid_resolution,
-                        width=TOP_DOWN_RENDER_PX,
-                        height=TOP_DOWN_RENDER_PX,
-                    )
-                    self.cached_data = self._save_and_get_cache()
-                    # Inside the lock: otherwise every worker that generates a
-                    # scene keeps its Unity alive for the rest of the run, and
-                    # they accumulate exactly as the lock exists to prevent.
-                    self.controller.stop()
-                    self.controller = None
+                    from ._display import screen_at_least
+
+                    with screen_at_least(TOP_DOWN_RENDER_PX, TOP_DOWN_RENDER_PX):
+                        self.controller = Controller(
+                            scene=self.scene,
+                            gridSize=self.grid_resolution,
+                            width=TOP_DOWN_RENDER_PX,
+                            height=TOP_DOWN_RENDER_PX,
+                        )
+                        self.cached_data = self._save_and_get_cache()
+                        # Inside the lock: otherwise every worker that generates
+                        # a scene keeps its Unity alive for the rest of the run,
+                        # and they accumulate exactly as the lock exists to
+                        # prevent.
+                        self.controller.stop()
+                        self.controller = None
                 else:
                     print("-----------Using cached procthor data-----------")
                     self.controller = None

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -1,6 +1,7 @@
 """AI2-THOR interface for ProcTHOR environments."""
 
 import copy
+import io
 import json
 import os
 import pickle
@@ -26,17 +27,29 @@ IGNORE_CONTAINERS = [
     'box'
 ]
 
-SCENE_CACHE_VERSION = 2
-"""Version 2 adds ``image_ortho_extent_m``.
+SCENE_CACHE_VERSION = 3
+"""Version 2 adds ``image_ortho_extent_m``; version 3 stores images as JPEG.
 
-Stored even though :meth:`ThorInterface.top_down_footprint` recomputes it,
-because its *presence* is what distinguishes an image framed that way from a
-version 1 image framed on AI2-THOR's ``sceneBounds``. A missing extent degrades
-to no overhead image rather than relaunching Unity for every cached scene.
+The extent is stored even though :meth:`ThorInterface.top_down_footprint`
+recomputes it, because its *presence* is what distinguishes an image framed
+that way from a version 1 image framed on AI2-THOR's ``sceneBounds``. A missing
+extent degrades to no overhead image rather than relaunching Unity for every
+cached scene; raw-array images from either older version still load.
 """
 
 _MAP_VIEW_ROTATION = {"x": 90.0, "y": 0.0, "z": 0.0}
 """Straight down, with camera-right along world +x and camera-up along +z."""
+
+TOP_DOWN_RENDER_PX = 2048
+"""Square render size for the cached top-down images.
+
+Saved plots are dpi=300, which puts ~2000 pixels across the map axes; at the
+old 480 the image was upscaled about four times. Costs generation only -- the
+controller is stopped as soon as the cache is written.
+"""
+
+JPEG_QUALITY = 75
+"""Cached images are JPEG, which is ~50x smaller than raw at this size."""
 
 TOP_DOWN_MARGIN_M = 0.5
 """Slack around the room polygons, for wall thickness and exterior trim."""
@@ -47,6 +60,23 @@ _EXTENT_WARNED: set = set()
 Not left to ``warnings``' own deduplication, which is reset to "always" inside
 ``pytest.warns``.
 """
+
+
+def _encode_image(image: np.ndarray) -> bytes:
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.fromarray(image).save(buffer, "JPEG", quality=JPEG_QUALITY)
+    return buffer.getvalue()
+
+
+def _decode_image(data: Any) -> Any:
+    """Cached images are JPEG bytes; older caches hold raw arrays."""
+    if not isinstance(data, bytes):
+        return data
+    from PIL import Image
+
+    return np.array(Image.open(io.BytesIO(data)).convert("RGB"))
 
 
 def _is_axis_aligned_top_down(rotation: Any) -> bool:
@@ -106,8 +136,8 @@ class ThorInterface:
                     self.controller = Controller(
                         scene=self.scene,
                         gridSize=self.grid_resolution,
-                        width=480,
-                        height=480
+                        width=TOP_DOWN_RENDER_PX,
+                        height=TOP_DOWN_RENDER_PX,
                     )
                     self.cached_data = self._save_and_get_cache()
                     # Inside the lock: otherwise every worker that generates a
@@ -167,8 +197,8 @@ class ThorInterface:
         cache = {
             'cache_version': SCENE_CACHE_VERSION,
             'reachable_positions': self._get_reachable_positions_from_controller(),
-            'image_ortho': image_ortho,
-            'image_persp': image_persp,
+            'image_ortho': _encode_image(image_ortho),
+            'image_persp': _encode_image(image_persp),
             # Meters, not cells: the filename encodes no resolution, but
             # `resolution` is a constructor argument, so cells would silently
             # corrupt any run that does not use the default. Plain floats, not
@@ -527,7 +557,7 @@ class ThorInterface:
         """Get top-down image (from cache or controller)."""
         if self.cached_data is not None:
             key = 'image_ortho' if orthographic else 'image_persp'
-            return self.cached_data[key]
+            return _decode_image(self.cached_data[key])
         return self._render_top_down_from_controller(orthographic)[0]
 
     def get_top_down_view(self) -> Optional[TopDownView]:
@@ -538,7 +568,7 @@ class ThorInterface:
         image can only be drawn misaligned, which is worse than no image.
         """
         if self.cached_data is not None:
-            image = self.cached_data.get('image_ortho')
+            image = _decode_image(self.cached_data.get('image_ortho'))
             extent_m = self.cached_data.get('image_ortho_extent_m')
             if image is None or extent_m is None:
                 self._warn_unplaceable(

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -4,12 +4,14 @@ import copy
 import json
 import pickle
 import random
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from shapely import geometry
 
+from railroad.environment.types import TopDownView
 from railroad.navigation import pathing
 from .scenegraph import SceneGraph
 from . import utils
@@ -21,6 +23,44 @@ IGNORE_CONTAINERS = [
     'showerhead', 'television', 'vacuumcleaner', 'photo', 'plunger',
     'box'
 ]
+
+SCENE_CACHE_VERSION = 2
+"""Version 2 adds ``image_ortho_extent_m``.
+
+The extent is recomputable from the scene JSON via
+:meth:`ThorInterface.top_down_footprint`, but it is stored anyway, because its
+*presence* is what distinguishes an image rendered with that footprint from a
+version 1 image framed on AI2-THOR's ``sceneBounds``. Recomputing a footprint
+and applying it to a version 1 image would misalign it silently.
+
+Bumping this does *not* invalidate older caches: a scene missing the extent
+degrades to no overhead image rather than relaunching Unity for every scene
+already on disk.
+"""
+
+_MAP_VIEW_ROTATION = {"x": 90.0, "y": 0.0, "z": 0.0}
+"""Straight down, with camera-right along world +x and camera-up along +z."""
+
+TOP_DOWN_MARGIN_M = 0.5
+"""Slack around the room polygons, for wall thickness and exterior trim."""
+
+_EXTENT_WARNED: set = set()
+"""Seeds already warned about, so a per-frame render path stays quiet.
+
+Deliberately not left to ``warnings``' own deduplication, which keys on
+(message, category, module, lineno) and is reset to "always" inside
+``pytest.warns``.
+"""
+
+
+def _is_axis_aligned_top_down(rotation: Any) -> bool:
+    """Whether *rotation* already points straight down with no yaw."""
+    if not isinstance(rotation, dict):
+        return False
+    return all(
+        abs(float(rotation.get(axis, 0.0)) - expected) < 1e-6
+        for axis, expected in _MAP_VIEW_ROTATION.items()
+    )
 
 
 class ThorInterface:
@@ -121,10 +161,19 @@ class ThorInterface:
 
     def _save_and_get_cache(self, path: Optional[str] = None) -> Dict:
         """Cache expensive computations."""
+        image_ortho, extent_m = self._render_top_down_from_controller(orthographic=True)
+        image_persp, _ = self._render_top_down_from_controller(orthographic=False)
         cache = {
+            'cache_version': SCENE_CACHE_VERSION,
             'reachable_positions': self._get_reachable_positions_from_controller(),
-            'image_ortho': self._get_top_down_image_from_controller(orthographic=True),
-            'image_persp': self._get_top_down_image_from_controller(orthographic=False)
+            'image_ortho': image_ortho,
+            'image_persp': image_persp,
+            # Meters, not cells: the filename encodes no resolution, but
+            # `resolution` is a constructor argument, so cells would silently
+            # corrupt any run that does not use the default. Plain floats, not
+            # a dataclass -- pickling one pins its module path, and renaming it
+            # later would turn every cache into an AttributeError on load.
+            'image_ortho_extent_m': extent_m,
         }
         save_dir = Path(path) if path is not None else self._cache_dir()
         save_dir.mkdir(parents=True, exist_ok=True)
@@ -157,10 +206,30 @@ class ThorInterface:
         """Set grid coordinate offset."""
         self.grid_offset = np.array([min_x, min_y])
 
+    def scale_to_grid_continuous(
+        self, point: Union[Tuple[float, float], Sequence[float]]
+    ) -> Tuple[float, float]:
+        """World (x, z) meters -> fractional grid cells.
+
+        Integers land on cell centers, which is exactly where matplotlib
+        places them. Callers positioning an image need the unrounded value:
+        rounding an outer edge to a cell center shifts it by up to half a cell.
+        """
+        x = (point[0] - self.grid_offset[0]) / self.grid_resolution
+        y = (point[1] - self.grid_offset[1]) / self.grid_resolution
+        return x, y
+
     def scale_to_grid(self, point: Union[Tuple[float, float], Sequence[float]]) -> Tuple[int, int]:
         """Convert world coordinates to grid coordinates."""
-        x = round((point[0] - self.grid_offset[0]) / self.grid_resolution)
-        y = round((point[1] - self.grid_offset[1]) / self.grid_resolution)
+        x, y = self.scale_to_grid_continuous(point)
+        return round(x), round(y)
+
+    def grid_to_world(
+        self, cell: Union[Tuple[float, float], Sequence[float]]
+    ) -> Tuple[float, float]:
+        """Inverse of :meth:`scale_to_grid`: world (x, z) at a cell's center."""
+        x = float(cell[0]) * self.grid_resolution + float(self.grid_offset[0])
+        y = float(cell[1]) * self.grid_resolution + float(self.grid_offset[1])
         return x, y
 
     def _get_robot_pose(self) -> Tuple[int, int]:
@@ -314,8 +383,48 @@ class ThorInterface:
 
         return known_cost
 
-    def _get_top_down_image_from_controller(self, orthographic: bool = True) -> np.ndarray:
-        """Get top-down image from controller."""
+    def top_down_footprint(self) -> Tuple[float, float, float, float]:
+        """World footprint the top-down camera frames, ``(min_x, max_x, min_z, max_z)``.
+
+        Chosen here rather than taken from AI2-THOR's map-view camera, so that
+        it is known exactly and offline. THOR frames on ``sceneBounds``, the
+        union of every enabled renderer's bounds -- which sweeps in geometry
+        that is not visible from above (ceilings, roof overhang) by a
+        scene-dependent amount, and is inconsistent enough across ProcTHOR-10k
+        that deriving world coordinates from it is an open upstream bug
+        (allenai/ai2thor#1181). Nothing downstream could then say where a pixel
+        sits without re-reading numbers only a live Unity has.
+
+        The room floor polygons are exact, in the scene JSON, and the walls sit
+        on their boundary -- so the house footprint plus a small margin frames
+        the whole scene, including rooms the agent cannot enter.
+
+        Square, because a third-party camera inherits the main camera's
+        resolution and ``orthographicSize`` is a half-height: a non-square
+        request could not be honoured.
+        """
+        corners = [
+            (vertex["x"], vertex["z"])
+            for room in self.rooms
+            for vertex in room["floorPolygon"]
+        ]
+        xs = [corner[0] for corner in corners]
+        zs = [corner[1] for corner in corners]
+        center_x = 0.5 * (min(xs) + max(xs))
+        center_z = 0.5 * (min(zs) + max(zs))
+        half = 0.5 * max(max(xs) - min(xs), max(zs) - min(zs)) + TOP_DOWN_MARGIN_M
+        return (center_x - half, center_x + half, center_z - half, center_z + half)
+
+    def _render_top_down_from_controller(
+        self, orthographic: bool = True
+    ) -> Tuple[np.ndarray, Optional[Tuple[float, float, float, float]]]:
+        """Render a top-down frame, plus its world footprint in meters.
+
+        The second element is ``(min_x, max_x, min_z, max_z)`` for the
+        orthographic camera and ``None`` for the perspective one -- a
+        projective view has no rectangular footprint, so there is nothing
+        honest to return.
+        """
         assert self.controller is not None
         event = self.controller.step(action="GetMapViewCameraProperties", raise_for_failure=True)
         pose = copy.deepcopy(event.metadata["actionReturn"])
@@ -323,12 +432,39 @@ class ThorInterface:
         bounds = event.metadata["sceneBounds"]["size"]
         max_bound = max(bounds["x"], bounds["z"])
 
+        # Pin the camera straight down. A non-zero yaw would rotate the world
+        # footprint out of axis-alignment, which no rectangular imshow extent
+        # can express -- the overlay would be silently skewed rather than
+        # obviously broken. Warn rather than swallow it if THOR ever disagrees.
+        returned_rotation = pose.get("rotation")
+        pose["rotation"] = dict(_MAP_VIEW_ROTATION)
+        if orthographic and not _is_axis_aligned_top_down(returned_rotation):
+            warnings.warn(
+                f"AI2-THOR's map-view camera for scene {self.seed} returned "
+                f"rotation {returned_rotation}; overriding with "
+                f"{_MAP_VIEW_ROTATION} so the render stays axis-aligned.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
         pose["fieldOfView"] = 50
+        # Height only, so it never affects an orthographic footprint -- this is
+        # the one place sceneBounds stays useful, lifting the camera clear of
+        # whatever the scene contains.
         pose["position"]["y"] += 1.1 * max_bound
         pose["orthographic"] = orthographic
         pose["farClippingPlane"] = 50
+
+        extent_m = None
         if orthographic:
-            pose["orthographicSize"] = 0.5 * max_bound
+            extent_m = self.top_down_footprint()
+            min_x, max_x, min_z, max_z = extent_m
+            pose["position"]["x"] = 0.5 * (min_x + max_x)
+            pose["position"]["z"] = 0.5 * (min_z + max_z)
+            # Unity's orthographicSize is the camera's HALF-height in world
+            # units. The footprint is square and the frame is square, so this
+            # is also its half-width.
+            pose["orthographicSize"] = 0.5 * (max_z - min_z)
         else:
             del pose["orthographicSize"]
 
@@ -338,15 +474,99 @@ class ThorInterface:
             skyboxColor="white",
             raise_for_failure=True,
         )
-        image = event.third_party_camera_frames[-1]
-        return image[::-1, ...]
+        image = event.third_party_camera_frames[-1][::-1, ...]
+
+        if extent_m is not None:
+            # The footprint above assumes a square frame. Guard it rather than
+            # trust it: a non-square controller resolution would stretch the
+            # horizontal axis and silently skew every overlay.
+            height_px, width_px = image.shape[:2]
+            if height_px != width_px:
+                raise RuntimeError(
+                    f"top-down render is {width_px}x{height_px}; the orthographic "
+                    "footprint is only square when the frame is. Set the "
+                    "controller to a square resolution, or widen the footprint "
+                    "by the aspect ratio here."
+                )
+        return image, extent_m
 
     def get_top_down_image(self, orthographic: bool = True) -> np.ndarray:
         """Get top-down image (from cache or controller)."""
         if self.cached_data is not None:
             key = 'image_ortho' if orthographic else 'image_persp'
             return self.cached_data[key]
-        return self._get_top_down_image_from_controller(orthographic)
+        return self._render_top_down_from_controller(orthographic)[0]
+
+    def get_top_down_view(self) -> Optional[TopDownView]:
+        """The orthographic top-down image, placed on the occupancy grid.
+
+        Returns ``None`` -- after warning once for this scene -- when the
+        cached scene predates the recorded camera extent. An unpositioned
+        image can only be drawn misaligned, which is worse than no image.
+        """
+        if self.cached_data is not None:
+            image = self.cached_data.get('image_ortho')
+            extent_m = self.cached_data.get('image_ortho_extent_m')
+            if image is None or extent_m is None:
+                self._warn_missing_extent()
+                return None
+            # The footprint is recomputable, so a cache that disagrees with it
+            # was rendered against different framing -- a changed
+            # TOP_DOWN_MARGIN_M, say. Its pixels sit somewhere else than we
+            # would now say, so treat it as stale rather than misplace it.
+            expected = self.top_down_footprint()
+            if not np.allclose(extent_m, expected, atol=1e-6):
+                self._warn_stale_extent(extent_m, expected)
+                return None
+        else:
+            image, extent_m = self._render_top_down_from_controller(orthographic=True)
+            if extent_m is None:
+                return None
+        return self._view_from_extent(image, extent_m)
+
+    def _view_from_extent(
+        self, image: np.ndarray, extent_m: Tuple[float, float, float, float],
+    ) -> TopDownView:
+        """Place an image given its world footprint, in meters.
+
+        The bounds are the image's outer *edges*, and
+        ``scale_to_grid_continuous`` maps meters to cell coordinates where
+        integers are cell centers -- which is where matplotlib draws them. So
+        no half-cell correction belongs here: rounding to a cell index, as
+        ``scale_to_grid`` does, would put an outer edge on a center instead.
+        """
+        min_x, min_y = self.scale_to_grid_continuous((extent_m[0], extent_m[2]))
+        max_x, max_y = self.scale_to_grid_continuous((extent_m[1], extent_m[3]))
+        return TopDownView(
+            image=image, min_x=min_x, max_x=max_x, min_y=min_y, max_y=max_y,
+        )
+
+    def _warn_missing_extent(self) -> None:
+        """Warn once per scene that the cached image cannot be positioned."""
+        self._warn_unusable_cache(
+            "was cached before the top-down camera extent was recorded"
+        )
+
+    def _warn_stale_extent(self, cached: Any, expected: Any) -> None:
+        """Warn once per scene that the cached image was framed differently."""
+        self._warn_unusable_cache(
+            f"was rendered with the footprint {tuple(round(v, 3) for v in cached)}, "
+            f"but this build frames it at {tuple(round(v, 3) for v in expected)}"
+        )
+
+    def _warn_unusable_cache(self, reason: str) -> None:
+        """Warn once per scene, whatever made the cached image unplaceable."""
+        if self.seed in _EXTENT_WARNED:
+            return
+        _EXTENT_WARNED.add(self.seed)
+        warnings.warn(
+            f"ProcTHOR scene {self.seed} {reason}, so its overhead image cannot "
+            f"be aligned with the occupancy grid and will be omitted. Delete "
+            f"{self._cache_dir()} to regenerate it (this relaunches Unity for "
+            f"the scenes you use).",
+            RuntimeWarning,
+            stacklevel=4,
+        )
 
     def get_target_objs_info(self, num_objects: int = 1) -> Dict | List[Dict]:
         """Get info about target objects for search tasks."""

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -110,6 +110,11 @@ class ThorInterface:
                         height=480
                     )
                     self.cached_data = self._save_and_get_cache()
+                    # Inside the lock: otherwise every worker that generates a
+                    # scene keeps its Unity alive for the rest of the run, and
+                    # they accumulate exactly as the lock exists to prevent.
+                    self.controller.stop()
+                    self.controller = None
                 else:
                     print("-----------Using cached procthor data-----------")
                     self.controller = None
@@ -148,10 +153,10 @@ class ThorInterface:
     def _cache_dir(self) -> Path:
         """Where per-seed scene caches live.
 
-        Derived from the resources directory rather than hardcoded relative to
-        the working directory, so ``PROCTHOR_RESOURCES_DIR`` actually reaches
-        it. Without that, running from anywhere but the directory holding
-        ``resources/`` silently misses every cached scene and starts Unity.
+        Follows the resources directory, so ``PROCTHOR_RESOURCES_DIR`` reaches
+        it. Unset, that still falls back to ``Path.cwd() / "resources"`` fixed
+        at import, so running from elsewhere misses every cached scene and
+        starts Unity -- set the variable to work from more than one directory.
         """
         return get_procthor_10k_dir() / 'cache'
 

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -2,8 +2,10 @@
 
 import copy
 import json
+import os
 import pickle
 import random
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -177,18 +179,54 @@ class ThorInterface:
         }
         save_dir = Path(path) if path is not None else self._cache_dir()
         save_dir.mkdir(parents=True, exist_ok=True)
-        with open(save_dir / f'scene_{self.seed}.pkl', 'wb') as f:
-            pickle.dump(cache, f)
+        self._write_cache_atomically(cache, save_dir / f'scene_{self.seed}.pkl')
         return cache
 
+    @staticmethod
+    def _write_cache_atomically(cache: Dict, target: Path) -> None:
+        """Write *cache* to *target*, or leave whatever was there alone.
+
+        Dumping straight to the destination means a Ctrl-C or a crash partway
+        through leaves a truncated pickle that every later run fails to load --
+        the scene is then permanently broken rather than simply regenerated.
+        The window is not small: these are two 480x480 images plus thousands of
+        reachable positions, and generating them is slow enough that
+        interrupting the run is a normal thing to do.
+
+        Writing beside the target and renaming makes the swap atomic within a
+        filesystem, so a reader sees either the old file or the whole new one.
+        """
+        handle, temp_name = tempfile.mkstemp(
+            dir=target.parent, prefix=f'{target.stem}.', suffix='.tmp',
+        )
+        try:
+            with os.fdopen(handle, 'wb') as file:
+                pickle.dump(cache, file)
+            os.replace(temp_name, target)
+        except BaseException:  # including KeyboardInterrupt, the likely one
+            Path(temp_name).unlink(missing_ok=True)
+            raise
+
     def _load_cache(self, path: Optional[str] = None) -> Optional[Dict]:
-        """Load cached scene data."""
+        """Load cached scene data, treating an unreadable file as a miss."""
         base = Path(path) if path is not None else self._cache_dir()
         cache_file = base / f'scene_{self.seed}.pkl'
         if not cache_file.exists():
             return None
-        with open(cache_file, 'rb') as f:
-            return pickle.load(f)
+        try:
+            with open(cache_file, 'rb') as f:
+                return pickle.load(f)
+        except Exception as error:
+            # Recover from files written before the atomic swap above, rather
+            # than failing every run until someone deletes them by hand. Loud,
+            # because regenerating means starting Unity.
+            warnings.warn(
+                f"ProcTHOR scene cache {cache_file} could not be read "
+                f"({type(error).__name__}: {error}); regenerating it.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return None
 
     def _get_reachable_positions_from_controller(self) -> List[Dict[str, float]]:
         """Get reachable positions from controller."""

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -29,15 +29,10 @@ IGNORE_CONTAINERS = [
 SCENE_CACHE_VERSION = 2
 """Version 2 adds ``image_ortho_extent_m``.
 
-The extent is recomputable from the scene JSON via
-:meth:`ThorInterface.top_down_footprint`, but it is stored anyway, because its
-*presence* is what distinguishes an image rendered with that footprint from a
-version 1 image framed on AI2-THOR's ``sceneBounds``. Recomputing a footprint
-and applying it to a version 1 image would misalign it silently.
-
-Bumping this does *not* invalidate older caches: a scene missing the extent
-degrades to no overhead image rather than relaunching Unity for every scene
-already on disk.
+Stored even though :meth:`ThorInterface.top_down_footprint` recomputes it,
+because its *presence* is what distinguishes an image framed that way from a
+version 1 image framed on AI2-THOR's ``sceneBounds``. A missing extent degrades
+to no overhead image rather than relaunching Unity for every cached scene.
 """
 
 _MAP_VIEW_ROTATION = {"x": 90.0, "y": 0.0, "z": 0.0}
@@ -49,8 +44,7 @@ TOP_DOWN_MARGIN_M = 0.5
 _EXTENT_WARNED: set = set()
 """Seeds already warned about, so a per-frame render path stays quiet.
 
-Deliberately not left to ``warnings``' own deduplication, which keys on
-(message, category, module, lineno) and is reset to "always" inside
+Not left to ``warnings``' own deduplication, which is reset to "always" inside
 ``pytest.warns``.
 """
 
@@ -186,15 +180,11 @@ class ThorInterface:
     def _write_cache_atomically(cache: Dict, target: Path) -> None:
         """Write *cache* to *target*, or leave whatever was there alone.
 
-        Dumping straight to the destination means a Ctrl-C or a crash partway
-        through leaves a truncated pickle that every later run fails to load --
-        the scene is then permanently broken rather than simply regenerated.
-        The window is not small: these are two 480x480 images plus thousands of
-        reachable positions, and generating them is slow enough that
-        interrupting the run is a normal thing to do.
-
-        Writing beside the target and renaming makes the swap atomic within a
-        filesystem, so a reader sees either the old file or the whole new one.
+        Dumping straight to the destination leaves a truncated pickle on a
+        Ctrl-C, and the scene is then permanently broken rather than simply
+        regenerated. Not a small window: two 480x480 images plus thousands of
+        reachable positions, slow enough that interrupting is normal. Writing
+        beside the target and renaming makes the swap atomic.
         """
         handle, temp_name = tempfile.mkstemp(
             dir=target.parent, prefix=f'{target.stem}.', suffix='.tmp',
@@ -247,11 +237,10 @@ class ThorInterface:
     def scale_to_grid_continuous(
         self, point: Union[Tuple[float, float], Sequence[float]]
     ) -> Tuple[float, float]:
-        """World (x, z) meters -> fractional grid cells.
+        """World (x, z) meters -> fractional grid cells, unrounded.
 
-        Integers land on cell centers, which is exactly where matplotlib
-        places them. Callers positioning an image need the unrounded value:
-        rounding an outer edge to a cell center shifts it by up to half a cell.
+        Callers positioning an image need this: rounding an outer edge to a
+        cell center shifts it by up to half a cell.
         """
         x = (point[0] - self.grid_offset[0]) / self.grid_resolution
         y = (point[1] - self.grid_offset[1]) / self.grid_resolution
@@ -422,24 +411,18 @@ class ThorInterface:
         return known_cost
 
     def top_down_footprint(self) -> Tuple[float, float, float, float]:
-        """World footprint the top-down camera frames, ``(min_x, max_x, min_z, max_z)``.
+        """World footprint the camera frames, ``(min_x, max_x, min_z, max_z)``.
 
-        Chosen here rather than taken from AI2-THOR's map-view camera, so that
-        it is known exactly and offline. THOR frames on ``sceneBounds``, the
-        union of every enabled renderer's bounds -- which sweeps in geometry
-        that is not visible from above (ceilings, roof overhang) by a
-        scene-dependent amount, and is inconsistent enough across ProcTHOR-10k
-        that deriving world coordinates from it is an open upstream bug
-        (allenai/ai2thor#1181). Nothing downstream could then say where a pixel
-        sits without re-reading numbers only a live Unity has.
+        Chosen here rather than taken from THOR's map-view camera, so it is
+        known offline. THOR frames on ``sceneBounds`` -- the union of every
+        enabled renderer, which sweeps in geometry invisible from above and is
+        inconsistent enough across ProcTHOR-10k to be an open upstream bug
+        (allenai/ai2thor#1181).
 
-        The room floor polygons are exact, in the scene JSON, and the walls sit
-        on their boundary -- so the house footprint plus a small margin frames
-        the whole scene, including rooms the agent cannot enter.
-
-        Square, because a third-party camera inherits the main camera's
-        resolution and ``orthographicSize`` is a half-height: a non-square
-        request could not be honoured.
+        The room floor polygons are exact, in the scene JSON, with the walls on
+        their boundary, so the house plus a margin frames the whole scene
+        including rooms the agent cannot enter. Square, since a third-party
+        camera inherits the main camera's resolution.
         """
         corners = [
             (vertex["x"], vertex["z"])
@@ -546,7 +529,9 @@ class ThorInterface:
             image = self.cached_data.get('image_ortho')
             extent_m = self.cached_data.get('image_ortho_extent_m')
             if image is None or extent_m is None:
-                self._warn_missing_extent()
+                self._warn_unplaceable(
+                    "was cached before the top-down camera extent was recorded"
+                )
                 return None
             # The footprint is recomputable, so a cache that disagrees with it
             # was rendered against different framing -- a changed
@@ -554,7 +539,11 @@ class ThorInterface:
             # would now say, so treat it as stale rather than misplace it.
             expected = self.top_down_footprint()
             if not np.allclose(extent_m, expected, atol=1e-6):
-                self._warn_stale_extent(extent_m, expected)
+                self._warn_unplaceable(
+                    f"was rendered with the footprint "
+                    f"{tuple(round(v, 3) for v in extent_m)}, but this build "
+                    f"frames it at {tuple(round(v, 3) for v in expected)}"
+                )
                 return None
         else:
             image, extent_m = self._render_top_down_from_controller(orthographic=True)
@@ -567,11 +556,10 @@ class ThorInterface:
     ) -> TopDownView:
         """Place an image given its world footprint, in meters.
 
-        The bounds are the image's outer *edges*, and
-        ``scale_to_grid_continuous`` maps meters to cell coordinates where
-        integers are cell centers -- which is where matplotlib draws them. So
-        no half-cell correction belongs here: rounding to a cell index, as
-        ``scale_to_grid`` does, would put an outer edge on a center instead.
+        The bounds are outer *edges*, and ``scale_to_grid_continuous`` maps
+        meters to cell coordinates where integers are cell centers, which is
+        where matplotlib draws them. So no half-cell correction belongs here --
+        rounding, as ``scale_to_grid`` does, would put an edge on a center.
         """
         min_x, min_y = self.scale_to_grid_continuous((extent_m[0], extent_m[2]))
         max_x, max_y = self.scale_to_grid_continuous((extent_m[1], extent_m[3]))
@@ -579,21 +567,8 @@ class ThorInterface:
             image=image, min_x=min_x, max_x=max_x, min_y=min_y, max_y=max_y,
         )
 
-    def _warn_missing_extent(self) -> None:
-        """Warn once per scene that the cached image cannot be positioned."""
-        self._warn_unusable_cache(
-            "was cached before the top-down camera extent was recorded"
-        )
-
-    def _warn_stale_extent(self, cached: Any, expected: Any) -> None:
-        """Warn once per scene that the cached image was framed differently."""
-        self._warn_unusable_cache(
-            f"was rendered with the footprint {tuple(round(v, 3) for v in cached)}, "
-            f"but this build frames it at {tuple(round(v, 3) for v in expected)}"
-        )
-
-    def _warn_unusable_cache(self, reason: str) -> None:
-        """Warn once per scene, whatever made the cached image unplaceable."""
+    def _warn_unplaceable(self, reason: str) -> None:
+        """Warn once per scene that its cached image cannot be positioned."""
         if self.seed in _EXTENT_WARNED:
             return
         _EXTENT_WARNED.add(self.seed)
@@ -603,9 +578,8 @@ class ThorInterface:
             f"{self._cache_dir()} to regenerate it (this relaunches Unity for "
             f"the scenes you use).",
             RuntimeWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
-
     def get_target_objs_info(self, num_objects: int = 1) -> Dict | List[Dict]:
         """Get info about target objects for search tasks."""
         object_name_to_idxs: Dict[str, List[int]] = {}

--- a/packages/railroad/src/railroad/environment/railsim/README.md
+++ b/packages/railroad/src/railroad/environment/railsim/README.md
@@ -91,9 +91,15 @@ space is around the corner. Offices have no goal path and no breadcrumbs.
 ## Integration with railroad
 
 `RailsimScene` mirrors the `ProcTHORScene` data-provider surface (`.grid`,
-`.locations`, `.object_locations`, `.get_top_down_image()`), so railsim worlds
-plug into the unknown-space exploration stack unchanged. `object_locations`
-is empty: railsim scenes are exploration-only.
+`.locations`, `.object_locations`, `.get_top_down_image()`,
+`.get_top_down_view()`), so railsim worlds plug into the unknown-space
+exploration stack unchanged. `object_locations` is empty: railsim scenes are
+exploration-only.
+
+`get_top_down_view()` returns a `TopDownView` — the same image positioned in
+occupancy-grid cells, which is what lets the dashboard draw it underneath a
+trajectory. Note it transposes: `get_top_down_image()` is indexed `[x, y]` like
+the grid, while the plot draws `grid.T`.
 
 `VisualUnknownSpaceEnvironment` subclasses
 `railroad.experimental.unknown_search.UnknownSpaceEnvironment` and hooks

--- a/packages/railroad/src/railroad/environment/railsim/maps.py
+++ b/packages/railroad/src/railroad/environment/railsim/maps.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Dict, Set, Tuple
 
 import numpy as np
 
-from railroad.environment.types import PoseLike
+from railroad.environment.types import PoseLike, TopDownView
 from railroad.navigation.pathing import inflate_grid
 
 from .environments import (
@@ -223,6 +223,19 @@ class RailsimScene:
             table_color = np.array(palette.get("table", (0.36, 0.21, 0.06)))
             image[occupied & (semantic == clutter_label)] = table_color
         return (image * 255).astype(np.uint8)
+
+    def get_top_down_view(self) -> TopDownView:
+        """Semantic top-down map, positioned on the occupancy grid."""
+        # get_top_down_image is indexed [x, y] like the grid itself, but the
+        # trajectory plot draws grid.T -- row = y, col = x. Transposing only
+        # here leaves get_top_down_image's own shape contract untouched.
+        image = np.transpose(self.get_top_down_image(), (1, 0, 2))
+        n_y, n_x = image.shape[:2]
+        # The image is exactly one pixel per cell, so these are the same
+        # bounds imshow would infer for the grid itself.
+        return TopDownView(
+            image=image, min_x=-0.5, max_x=n_x - 0.5, min_y=-0.5, max_y=n_y - 0.5,
+        )
 
     def release(self) -> None:
         """Release the simulator's GPU resources (safe if never created)."""

--- a/packages/railroad/src/railroad/environment/types.py
+++ b/packages/railroad/src/railroad/environment/types.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @runtime_checkable
@@ -33,3 +36,43 @@ class Pose:
     x: float
     y: float
     yaw: float = 0.0
+
+
+@dataclass(frozen=True)
+class TopDownView:
+    """A top-down scene image positioned in occupancy-grid cell coordinates.
+
+    Scenes render their overhead view in their own native frame -- metres for
+    ProcTHOR, cells for railsim -- so each provider converts to grid cells here.
+    That lets the dashboard draw the image underneath a trajectory without
+    knowing anything about the scene's units.
+
+    Attributes:
+        image: Row-major RGB array, row 0 at ``min_y`` and column 0 at ``min_x``.
+        min_x: Left edge along the plot's data-x axis (the grid's first index).
+        max_x: Right edge along data-x.
+        min_y: Top edge along the plot's data-y axis (the grid's second index).
+        max_y: Bottom edge along data-y.
+
+    The bounds are the image's *outer edges*, in the same continuous cell units
+    the occupancy grid is drawn in -- where cell ``k`` is centred on ``k`` and
+    spans ``k - 0.5`` to ``k + 0.5``.
+    """
+
+    image: np.ndarray
+    min_x: float
+    max_x: float
+    min_y: float
+    max_y: float
+
+    @property
+    def extent(self) -> tuple[float, float, float, float]:
+        """The ``imshow(extent=...)`` 4-tuple, for ``origin="upper"``.
+
+        Matplotlib always orders this ``(left, right, bottom, top)`` whatever
+        *origin* is; with ``origin="upper"`` row 0 is drawn at *top*. Since row
+        0 is ``min_y``, ``bottom`` comes out greater than ``top`` -- which is
+        what keeps the y axis increasing downwards, matching how the occupancy
+        grid is drawn.
+        """
+        return (self.min_x, self.max_x, self.max_y, self.min_y)

--- a/packages/railroad/src/railroad/environment/types.py
+++ b/packages/railroad/src/railroad/environment/types.py
@@ -42,21 +42,13 @@ class Pose:
 class TopDownView:
     """A top-down scene image positioned in occupancy-grid cell coordinates.
 
-    Scenes render their overhead view in their own native frame -- metres for
-    ProcTHOR, cells for railsim -- so each provider converts to grid cells here.
-    That lets the dashboard draw the image underneath a trajectory without
-    knowing anything about the scene's units.
+    Scenes render in their own units -- metres for ProcTHOR, cells for
+    railsim -- and convert here, so the dashboard can draw the image under a
+    trajectory without knowing anything about the scene.
 
-    Attributes:
-        image: Row-major RGB array, row 0 at ``min_y`` and column 0 at ``min_x``.
-        min_x: Left edge along the plot's data-x axis (the grid's first index).
-        max_x: Right edge along data-x.
-        min_y: Top edge along the plot's data-y axis (the grid's second index).
-        max_y: Bottom edge along data-y.
-
-    The bounds are the image's *outer edges*, in the same continuous cell units
-    the occupancy grid is drawn in -- where cell ``k`` is centred on ``k`` and
-    spans ``k - 0.5`` to ``k + 0.5``.
+    The bounds are the image's *outer edges*, in the continuous cell units the
+    grid is drawn in, where cell ``k`` is centred on ``k`` and spans ``k-0.5``
+    to ``k+0.5``. ``image`` is row-major with row 0 at ``min_y``.
     """
 
     image: np.ndarray
@@ -69,10 +61,9 @@ class TopDownView:
     def extent(self) -> tuple[float, float, float, float]:
         """The ``imshow(extent=...)`` 4-tuple, for ``origin="upper"``.
 
-        Matplotlib always orders this ``(left, right, bottom, top)`` whatever
-        *origin* is; with ``origin="upper"`` row 0 is drawn at *top*. Since row
-        0 is ``min_y``, ``bottom`` comes out greater than ``top`` -- which is
-        what keeps the y axis increasing downwards, matching how the occupancy
-        grid is drawn.
+        Always ordered ``(left, right, bottom, top)`` whatever *origin* is, and
+        ``origin="upper"`` draws row 0 at *top*. Row 0 being ``min_y``,
+        ``bottom`` comes out greater than ``top`` -- which keeps the y axis
+        increasing downwards, as the grid is drawn.
         """
         return (self.min_x, self.max_x, self.max_y, self.min_y)

--- a/packages/railroad/src/railroad/navigation/plotting.py
+++ b/packages/railroad/src/railroad/navigation/plotting.py
@@ -32,6 +32,48 @@ def make_plotting_grid(grid_map: np.ndarray) -> np.ndarray:
     return grid
 
 
+PHOTO_UNDERLAY_ALPHA = {
+    "free": 0.15, "boundary": 1.0, "obstacle": 0.15, "unknown": 0.95,
+}
+"""Per-class opacity when an aligned scene image is drawn underneath.
+
+Obstacle *outlines* stay opaque so the map still reads as a map, but obstacle
+*interiors* go nearly transparent -- that is where the scene image earns its
+place, and in ProcTHOR every cell that is not an agent-reachable position is
+"occupied", so an opaque interior would blot out the entire house.
+
+Unobserved cells stay nearly opaque. In an exploration run the observed /
+unobserved boundary is the most important thing on the plot, and letting the
+image bleed through the unobserved side blurs exactly that line -- it also
+shows the robot something it has not seen. Free space takes only a light wash,
+enough to lift the floor under a trail without hiding what is on it.
+"""
+
+
+def make_plotting_grid_alpha(
+    grid_map: np.ndarray, *,
+    free: float, boundary: float, obstacle: float, unknown: float,
+) -> np.ndarray:
+    """Per-cell opacity mask matching ``make_plotting_grid``'s classes.
+
+    Classifies exactly as ``make_plotting_grid`` does, so the two cannot drift
+    apart, but splits its single gray fill into *obstacle* interiors and
+    *unknown* (unobserved or outside-the-map) cells -- they render alike, yet
+    want opposite treatment over a scene image. Returns an (H, W) float array
+    for ``imshow(alpha=...)``.
+    """
+    collision = grid_map >= 0.5
+    thinned = erosion(collision, footprint=np.ones((3, 3)))
+    is_boundary = np.logical_xor(collision, thinned)
+    is_free = np.logical_and(grid_map < 0.5, grid_map >= FREE_VAL)
+
+    alpha = np.full(grid_map.shape, unknown, dtype=float)
+    alpha[collision] = obstacle
+    alpha[is_free] = free
+    alpha[is_boundary] = boundary
+    return alpha
+
+
 def make_plotting_grid_rgba(grid_map: np.ndarray) -> np.ndarray:
     """Convert occupancy grid to RGBA plotting grid.
 
@@ -82,7 +124,9 @@ def plot_grid_background(
     ax: Any,
     observed_grid: np.ndarray,
     true_grid: np.ndarray | None = None,
-) -> None:
+    *,
+    translucent: bool = False,
+) -> Any:
     """Render occupancy grid background with optional faded true-grid underlay.
 
     If *true_grid* is provided and *observed_grid* contains unobserved cells,
@@ -92,7 +136,17 @@ def plot_grid_background(
 
     Both paths transpose the grid (``grid.T``) before rendering, matching the
     existing ``plot_grid`` convention.
+
+    Set *translucent* when an aligned scene image sits at a lower zorder, to
+    let it show through per cell class (see ``PHOTO_UNDERLAY_ALPHA``). The
+    default renders fully opaque, exactly as before.
+
+    Returns the ``AxesImage`` that was drawn.
     """
+    alpha = None
+    if translucent:
+        alpha = make_plotting_grid_alpha(observed_grid.T, **PHOTO_UNDERLAY_ALPHA)
+
     has_unknown = bool(np.any(observed_grid == UNOBSERVED_VAL))
     if true_grid is not None and has_unknown:
         # Composite in numpy so the true-grid underlay blends against the
@@ -109,9 +163,10 @@ def plot_grid_background(
         obs_alpha = observed_rgba[:, :, 3:4]
         composite = composite * (1 - obs_alpha) + observed_rgba[:, :, :3] * obs_alpha
 
-        ax.imshow(composite, origin="upper", zorder=0)
-    else:
-        ax.imshow(make_plotting_grid(observed_grid.T), origin="upper", zorder=0)
+        return ax.imshow(composite, origin="upper", zorder=0, alpha=alpha)
+    return ax.imshow(
+        make_plotting_grid(observed_grid.T), origin="upper", zorder=0, alpha=alpha,
+    )
 
 
 def plot_grid(ax: Any, grid: np.ndarray) -> None:

--- a/packages/railroad/src/railroad/navigation/plotting.py
+++ b/packages/railroad/src/railroad/navigation/plotting.py
@@ -32,24 +32,16 @@ def make_plotting_grid(grid_map: np.ndarray) -> np.ndarray:
     return grid
 
 
-PHOTO_UNDERLAY_ALPHA = {
-    "free": 0.0, "boundary": 0.0, "obstacle": 0.0, "unknown": 0.0,
-}
-"""Per-class grid opacity when an aligned scene image is drawn underneath.
+PHOTO_UNDERLAY_ALPHA = 0.0
+"""Grid opacity when an aligned scene image is drawn underneath.
 
-All zero: the grid says nothing the image does not say better, and filling
+Invisible: the grid says nothing the image does not say better, and filling
 whole regions hides the map it is drawn on. What an image genuinely cannot
 show -- which parts the robot has actually looked at -- is drawn as an outline
 instead, by ``make_known_boundary_rgba``.
 
-The grid is still drawn rather than skipped, which keeps the layering, the
-alpha plumbing and the per-class classification exercised instead of rotting
--- raising any of these brings the grid straight back. The classes stay
-separate because they want different treatment if that happens: obstacle
-*outlines* can be opaque, since they are what makes a plot read as a map, but
-obstacle *interiors* must stay faint, because in ProcTHOR every cell that is
-not an agent-reachable position is "occupied" and an opaque interior blots out
-the entire house.
+Still drawn rather than skipped, so the layering and the alpha plumbing stay
+exercised instead of rotting; raising this brings the grid straight back.
 """
 
 KNOWN_WALL_COLOR = (0.0, 0.0, 0.0)
@@ -76,24 +68,18 @@ def make_known_boundary_rgba(
 ) -> np.ndarray:
     """Outline of the region the robot has observed, as an RGBA overlay.
 
-    Drawn instead of shading the unobserved region, which buries the map under
-    a wash. The outline says the same thing -- here is how far the robot has
-    seen -- while leaving everything inside it legible.
-
-    The outline is split by *why* it ends. Black where an observed obstacle
-    stops it, so the robot knows what is there; grey where observed free space
-    runs into the unknown, which is a frontier and could still be explored.
+    Drawn instead of shading the unobserved region, which buries the map the
+    image is there to show. Split by *why* the outline ends: an observed
+    obstacle, or a frontier that could still be explored.
 
     Frontier cells use the same rule as
-    ``railroad.experimental.unknown_search.extract_frontiers``: an observed
-    free cell 8-adjacent to an unknown one. Repeated here rather than imported,
-    because plotting sits below the exploration package, and applied to the
-    grid rather than to the environment's live frontier list so that an
-    animated grid outlines the frame being drawn rather than the final state.
+    ``railroad.experimental.unknown_search.extract_frontiers`` -- an observed
+    free cell 8-adjacent to an unknown one -- repeated rather than imported,
+    since plotting sits below that package. Taken from the grid, not the
+    environment's live frontiers, so an animated grid outlines the frame being
+    drawn rather than the final state.
 
-    Returns ``(n_y, n_x, 4)``, transposed to match ``make_plotting_grid(grid.T)``
-    so grid cell (i, j) lands at pixel [j, i]. Everything off the outline is
-    fully transparent.
+    Returns ``(n_y, n_x, 4)``, transposed to match ``make_plotting_grid(grid.T)``.
     """
     from skimage.morphology import dilation
 
@@ -119,30 +105,6 @@ def make_known_boundary_rgba(
     rgba[is_frontier, :3] = frontier_color
     rgba[is_wall | is_frontier, 3] = alpha
     return np.transpose(rgba, (1, 0, 2))
-
-
-def make_plotting_grid_alpha(
-    grid_map: np.ndarray, *,
-    free: float, boundary: float, obstacle: float, unknown: float,
-) -> np.ndarray:
-    """Per-cell opacity mask matching ``make_plotting_grid``'s classes.
-
-    Classifies exactly as ``make_plotting_grid`` does, so the two cannot drift
-    apart, but splits its single gray fill into *obstacle* interiors and
-    *unknown* (unobserved or outside-the-map) cells -- they render alike, yet
-    want opposite treatment over a scene image. Returns an (H, W) float array
-    for ``imshow(alpha=...)``.
-    """
-    collision = grid_map >= 0.5
-    thinned = erosion(collision, footprint=np.ones((3, 3)))
-    is_boundary = np.logical_xor(collision, thinned)
-    is_free = np.logical_and(grid_map < 0.5, grid_map >= FREE_VAL)
-
-    alpha = np.full(grid_map.shape, unknown, dtype=float)
-    alpha[collision] = obstacle
-    alpha[is_free] = free
-    alpha[is_boundary] = boundary
-    return alpha
 
 
 def make_plotting_grid_rgba(grid_map: np.ndarray) -> np.ndarray:
@@ -215,9 +177,7 @@ def plot_grid_background(
 
     Returns the ``AxesImage`` that was drawn.
     """
-    alpha = None
-    if translucent:
-        alpha = make_plotting_grid_alpha(observed_grid.T, **PHOTO_UNDERLAY_ALPHA)
+    alpha = PHOTO_UNDERLAY_ALPHA if translucent else None
 
     has_unknown = bool(np.any(observed_grid == UNOBSERVED_VAL))
     if true_grid is not None and has_unknown:

--- a/packages/railroad/src/railroad/navigation/plotting.py
+++ b/packages/railroad/src/railroad/navigation/plotting.py
@@ -44,6 +44,28 @@ Still drawn rather than skipped, so the layering and the alpha plumbing stay
 exercised instead of rotting; raising this brings the grid straight back.
 """
 
+UNTRAVERSABLE_SHADE = 0.15
+"""How much to darken what the robot cannot stand on, over a scene image.
+
+An image shows the room, not the map: furniture the robot must go around looks
+much like floor from above. A wash over everything untraversable makes the
+space it can actually move through read at a glance.
+"""
+
+
+def make_untraversable_shade_rgba(
+    grid_map: np.ndarray, *, alpha: float = UNTRAVERSABLE_SHADE,
+) -> np.ndarray:
+    """Black wash over occupied and unobserved cells, transparent over free.
+
+    Returns ``(n_y, n_x, 4)``, transposed like the other overlays.
+    """
+    free = (grid_map >= FREE_VAL) & (grid_map < 0.5)
+    rgba = np.zeros((*grid_map.shape, 4), dtype=float)
+    rgba[~free, 3] = alpha
+    return np.transpose(rgba, (1, 0, 2))
+
+
 KNOWN_WALL_COLOR = (0.0, 0.0, 0.0)
 """Boundary the robot has seen the far side of -- an observed obstacle."""
 

--- a/packages/railroad/src/railroad/navigation/plotting.py
+++ b/packages/railroad/src/railroad/navigation/plotting.py
@@ -44,7 +44,7 @@ Still drawn rather than skipped, so the layering and the alpha plumbing stay
 exercised instead of rotting; raising this brings the grid straight back.
 """
 
-UNTRAVERSABLE_SHADE = 0.15
+UNTRAVERSABLE_SHADE = 0.25
 """How much to darken what the robot cannot stand on, over a scene image.
 
 An image shows the room, not the map: furniture the robot must go around looks
@@ -54,16 +54,37 @@ space it can actually move through read at a glance.
 
 
 def make_untraversable_shade_rgba(
-    grid_map: np.ndarray, *, alpha: float = UNTRAVERSABLE_SHADE,
-) -> np.ndarray:
+    grid_map: np.ndarray,
+    cover: tuple[float, float, float, float] | None = None,
+    *,
+    alpha: float = UNTRAVERSABLE_SHADE,
+) -> tuple[np.ndarray, tuple[float, float, float, float]]:
     """Black wash over occupied and unobserved cells, transparent over free.
 
-    Returns ``(n_y, n_x, 4)``, transposed like the other overlays.
+    *cover* is an ``imshow`` extent, in cell coordinates, the wash should reach.
+    A scene image is generally larger than the mapped area -- the grid spans
+    only the reachable bbox -- and everything beyond it is somewhere the robot
+    cannot be either, so the grid is padded out to meet it rather than leaving
+    that margin bright.
+
+    Returns the ``(n_y, n_x, 4)`` overlay, transposed like the others, and the
+    extent to draw it at.
     """
+    n_x, n_y = grid_map.shape
+    left, right, bottom, top = -0.5, n_x - 0.5, n_y - 0.5, -0.5
+    if cover is not None:
+        pad = [int(np.ceil(max(0.0, gap))) for gap in
+               (left - cover[0], cover[1] - right, top - cover[3], cover[2] - bottom)]
+        grid_map = np.pad(
+            grid_map, ((pad[0], pad[1]), (pad[2], pad[3])), constant_values=1.0,
+        )
+        left, right = left - pad[0], right + pad[1]
+        top, bottom = top - pad[2], bottom + pad[3]
+
     free = (grid_map >= FREE_VAL) & (grid_map < 0.5)
     rgba = np.zeros((*grid_map.shape, 4), dtype=float)
     rgba[~free, 3] = alpha
-    return np.transpose(rgba, (1, 0, 2))
+    return np.transpose(rgba, (1, 0, 2)), (left, right, bottom, top)
 
 
 KNOWN_WALL_COLOR = (0.0, 0.0, 0.0)

--- a/packages/railroad/src/railroad/navigation/plotting.py
+++ b/packages/railroad/src/railroad/navigation/plotting.py
@@ -33,20 +33,22 @@ def make_plotting_grid(grid_map: np.ndarray) -> np.ndarray:
 
 
 PHOTO_UNDERLAY_ALPHA = {
-    "free": 0.15, "boundary": 1.0, "obstacle": 0.15, "unknown": 0.95,
+    "free": 0.0, "boundary": 0.0, "obstacle": 0.0, "unknown": 0.0,
 }
 """Per-class opacity when an aligned scene image is drawn underneath.
 
-Obstacle *outlines* stay opaque so the map still reads as a map, but obstacle
-*interiors* go nearly transparent -- that is where the scene image earns its
-place, and in ProcTHOR every cell that is not an agent-reachable position is
-"occupied", so an opaque interior would blot out the entire house.
+Currently all zero: with a scene image behind it the grid is redundant, and
+the image reads better without it. The grid is still drawn, so the layering,
+alpha plumbing and per-class classification stay exercised rather than rotting
+-- raising any of these brings it straight back.
 
-Unobserved cells stay nearly opaque. In an exploration run the observed /
-unobserved boundary is the most important thing on the plot, and letting the
-image bleed through the unobserved side blurs exactly that line -- it also
-shows the robot something it has not seen. Free space takes only a light wash,
-enough to lift the floor under a trail without hiding what is on it.
+The classes are kept apart because they want opposite treatment if that
+happens. Obstacle *outlines* can be opaque, since they are what makes the plot
+read as a map, but obstacle *interiors* must stay faint: in ProcTHOR every cell
+that is not an agent-reachable position is "occupied", so an opaque interior
+blots out the entire house. Unobserved cells want the opposite again -- in an
+exploration run the observed / unobserved boundary is the most important thing
+on the plot, and letting ground truth bleed through blurs exactly that line.
 """
 
 

--- a/packages/railroad/src/railroad/navigation/plotting.py
+++ b/packages/railroad/src/railroad/navigation/plotting.py
@@ -35,21 +35,90 @@ def make_plotting_grid(grid_map: np.ndarray) -> np.ndarray:
 PHOTO_UNDERLAY_ALPHA = {
     "free": 0.0, "boundary": 0.0, "obstacle": 0.0, "unknown": 0.0,
 }
-"""Per-class opacity when an aligned scene image is drawn underneath.
+"""Per-class grid opacity when an aligned scene image is drawn underneath.
 
-Currently all zero: with a scene image behind it the grid is redundant, and
-the image reads better without it. The grid is still drawn, so the layering,
-alpha plumbing and per-class classification stay exercised rather than rotting
--- raising any of these brings it straight back.
+All zero: the grid says nothing the image does not say better, and filling
+whole regions hides the map it is drawn on. What an image genuinely cannot
+show -- which parts the robot has actually looked at -- is drawn as an outline
+instead, by ``make_known_boundary_rgba``.
 
-The classes are kept apart because they want opposite treatment if that
-happens. Obstacle *outlines* can be opaque, since they are what makes the plot
-read as a map, but obstacle *interiors* must stay faint: in ProcTHOR every cell
-that is not an agent-reachable position is "occupied", so an opaque interior
-blots out the entire house. Unobserved cells want the opposite again -- in an
-exploration run the observed / unobserved boundary is the most important thing
-on the plot, and letting ground truth bleed through blurs exactly that line.
+The grid is still drawn rather than skipped, which keeps the layering, the
+alpha plumbing and the per-class classification exercised instead of rotting
+-- raising any of these brings the grid straight back. The classes stay
+separate because they want different treatment if that happens: obstacle
+*outlines* can be opaque, since they are what makes a plot read as a map, but
+obstacle *interiors* must stay faint, because in ProcTHOR every cell that is
+not an agent-reachable position is "occupied" and an opaque interior blots out
+the entire house.
 """
+
+KNOWN_WALL_COLOR = (0.0, 0.0, 0.0)
+"""Boundary the robot has seen the far side of -- an observed obstacle."""
+
+FRONTIER_COLOR = (0.90, 0.10, 0.55)
+"""Boundary exploration could continue through.
+
+Saturated rather than a grey, because this is drawn over scene imagery whose
+palette is not ours to choose. A grey vanished against railsim's walls, which
+are themselves grey (0.58): only 0.12 apart in RGB. Magenta is the furthest of
+the obvious candidates from every colour railsim and ProcTHOR actually use --
+0.58 from its nearest, against lime's 0.24, which collides with railsim's green
+breadcrumbs.
+"""
+
+
+def make_known_boundary_rgba(
+    observed_grid: np.ndarray,
+    *,
+    wall_color: tuple[float, float, float] = KNOWN_WALL_COLOR,
+    frontier_color: tuple[float, float, float] = FRONTIER_COLOR,
+    alpha: float = 1.0,
+) -> np.ndarray:
+    """Outline of the region the robot has observed, as an RGBA overlay.
+
+    Drawn instead of shading the unobserved region, which buries the map under
+    a wash. The outline says the same thing -- here is how far the robot has
+    seen -- while leaving everything inside it legible.
+
+    The outline is split by *why* it ends. Black where an observed obstacle
+    stops it, so the robot knows what is there; grey where observed free space
+    runs into the unknown, which is a frontier and could still be explored.
+
+    Frontier cells use the same rule as
+    ``railroad.experimental.unknown_search.extract_frontiers``: an observed
+    free cell 8-adjacent to an unknown one. Repeated here rather than imported,
+    because plotting sits below the exploration package, and applied to the
+    grid rather than to the environment's live frontier list so that an
+    animated grid outlines the frame being drawn rather than the final state.
+
+    Returns ``(n_y, n_x, 4)``, transposed to match ``make_plotting_grid(grid.T)``
+    so grid cell (i, j) lands at pixel [j, i]. Everything off the outline is
+    fully transparent.
+    """
+    from skimage.morphology import dilation
+
+    unknown = observed_grid == UNOBSERVED_VAL
+    if not unknown.any():
+        return np.zeros((observed_grid.shape[1], observed_grid.shape[0], 4),
+                        dtype=float)
+
+    free = (observed_grid >= FREE_VAL) & (observed_grid < 0.5)
+    footprint = np.ones((3, 3))
+    # Off the end of the array counts as unknown, so the outline closes where
+    # the observed region runs to the map edge. Without this the boundary is
+    # simply missing along that stretch -- there is no unknown cell beyond it
+    # to detect -- and the outline leaks.
+    padded = np.pad(unknown, 1, constant_values=True)
+    touches_unknown = dilation(padded, footprint=footprint)[1:-1, 1:-1] & ~unknown
+
+    is_frontier = free & touches_unknown
+    is_wall = touches_unknown & ~free
+
+    rgba = np.zeros((*observed_grid.shape, 4), dtype=float)
+    rgba[is_wall, :3] = wall_color
+    rgba[is_frontier, :3] = frontier_color
+    rgba[is_wall | is_frontier, 3] = alpha
+    return np.transpose(rgba, (1, 0, 2))
 
 
 def make_plotting_grid_alpha(
@@ -139,9 +208,10 @@ def plot_grid_background(
     Both paths transpose the grid (``grid.T``) before rendering, matching the
     existing ``plot_grid`` convention.
 
-    Set *translucent* when an aligned scene image sits at a lower zorder, to
-    let it show through per cell class (see ``PHOTO_UNDERLAY_ALPHA``). The
-    default renders fully opaque, exactly as before.
+    Set *translucent* when an aligned scene image sits at a lower zorder, so
+    the grid gets out of its way (see ``PHOTO_UNDERLAY_ALPHA``); what the
+    image cannot show is drawn as an outline by ``make_known_boundary_rgba``
+    instead. The default renders fully opaque, exactly as before.
 
     Returns the ``AxesImage`` that was drawn.
     """

--- a/packages/railroad/tests/environment/procthor/test_display.py
+++ b/packages/railroad/tests/environment/procthor/test_display.py
@@ -1,0 +1,47 @@
+"""Growing a headless X screen so AI2-THOR will render into it."""
+
+import subprocess
+
+from railroad.environment.procthor import _display
+
+HEADLESS = "Screen 0: minimum 8 x 8, current 1024 x 768, maximum 32767 x 32767\nDP-0 disconnected\n"
+WITH_MONITOR = "Screen 0: minimum 8 x 8, current 1024 x 768, maximum 32767 x 32767\nDP-0 connected primary 1024x768+0+0\n"
+
+
+def _patch(monkeypatch, listing: str, calls: list):
+    def run(args, **kwargs):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, listing, "")
+
+    monkeypatch.setattr(_display.subprocess, "run", run)
+    monkeypatch.setattr(_display.shutil, "which", lambda _name: "/usr/bin/xrandr")
+    monkeypatch.setenv("DISPLAY", ":0")
+
+
+def test_a_headless_screen_grows_and_is_put_back(monkeypatch):
+    calls: list = []
+    _patch(monkeypatch, HEADLESS, calls)
+
+    with _display.screen_at_least(2048, 2048) as grew:
+        assert grew
+
+    assert calls[1] == ["xrandr", "--fb", "2048x2048"]
+    assert calls[2] == ["xrandr", "--fb", "1024x768"]
+
+
+def test_a_screen_someone_is_looking_at_is_left_alone(monkeypatch):
+    """Growing the framebuffer past the monitor makes the desktop pan."""
+    calls: list = []
+    _patch(monkeypatch, WITH_MONITOR, calls)
+
+    with _display.screen_at_least(2048, 2048) as grew:
+        assert not grew
+
+    assert all("--fb" not in call for call in calls)
+
+
+def test_no_display_is_not_an_error(monkeypatch):
+    """macOS has no X screen to size, and no resolution check either."""
+    monkeypatch.delenv("DISPLAY", raising=False)
+    with _display.screen_at_least(2048, 2048) as grew:
+        assert not grew

--- a/packages/railroad/tests/environment/procthor/test_display.py
+++ b/packages/railroad/tests/environment/procthor/test_display.py
@@ -2,46 +2,49 @@
 
 import subprocess
 
+import pytest
+
 from railroad.environment.procthor import _display
 
-HEADLESS = "Screen 0: minimum 8 x 8, current 1024 x 768, maximum 32767 x 32767\nDP-0 disconnected\n"
-WITH_MONITOR = "Screen 0: minimum 8 x 8, current 1024 x 768, maximum 32767 x 32767\nDP-0 connected primary 1024x768+0+0\n"
+SCREEN = "Screen 0: minimum 8 x 8, current 1024 x 768, maximum 32767 x 32767\n"
 
 
-def _patch(monkeypatch, listing: str, calls: list):
+def _patch(monkeypatch, outputs: str) -> list:
+    calls: list = []
+
     def run(args, **kwargs):
         calls.append(list(args))
-        return subprocess.CompletedProcess(args, 0, listing, "")
+        return subprocess.CompletedProcess(args, 0, SCREEN + outputs, "")
 
     monkeypatch.setattr(_display.subprocess, "run", run)
     monkeypatch.setattr(_display.shutil, "which", lambda _name: "/usr/bin/xrandr")
+    return calls
+
+
+@pytest.mark.parametrize("outputs, grows", [("DP-0 disconnected", True),
+                                            ("DP-0 connected primary", False)])
+def test_only_an_unwatched_screen_is_grown(outputs, grows, monkeypatch):
+    """Growing the framebuffer past an attached monitor makes the desktop pan."""
+    calls = _patch(monkeypatch, outputs)
     monkeypatch.setenv("DISPLAY", ":0")
 
+    with _display.screen_at_least(2048, 2048) as grew:
+        assert grew is grows
 
-def test_a_headless_screen_grows_and_is_put_back(monkeypatch):
-    calls: list = []
-    _patch(monkeypatch, HEADLESS, calls)
+    assert [c for c in calls if "--fb" in c] == ([
+        ["xrandr", "-d", ":0", "--fb", "2048x2048"],
+        ["xrandr", "-d", ":0", "--fb", "1024x768"],
+    ] if grows else [])
+
+
+def test_an_unset_display_is_still_found(monkeypatch):
+    """AI2-THOR globs the socket directory rather than reading DISPLAY, so an
+    unset variable is no reason to leave the screen too small for it."""
+    calls = _patch(monkeypatch, "DP-0 disconnected")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setattr(_display.glob, "glob", lambda _p: ["/tmp/.X11-unix/X0"])
 
     with _display.screen_at_least(2048, 2048) as grew:
         assert grew
 
-    assert calls[1] == ["xrandr", "--fb", "2048x2048"]
-    assert calls[2] == ["xrandr", "--fb", "1024x768"]
-
-
-def test_a_screen_someone_is_looking_at_is_left_alone(monkeypatch):
-    """Growing the framebuffer past the monitor makes the desktop pan."""
-    calls: list = []
-    _patch(monkeypatch, WITH_MONITOR, calls)
-
-    with _display.screen_at_least(2048, 2048) as grew:
-        assert not grew
-
-    assert all("--fb" not in call for call in calls)
-
-
-def test_no_display_is_not_an_error(monkeypatch):
-    """macOS has no X screen to size, and no resolution check either."""
-    monkeypatch.delenv("DISPLAY", raising=False)
-    with _display.screen_at_least(2048, 2048) as grew:
-        assert not grew
+    assert ["xrandr", "-d", ":0", "--fb", "2048x2048"] in calls

--- a/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
@@ -93,6 +93,20 @@ class TestTheCacheSurvivesAnInterruptedWrite:
         # And no half-written temporary file left lying beside it.
         assert [p.name for p in tmp_path.iterdir()] == ["scene_5.pkl"]
 
+    def test_a_written_cache_is_readable_by_whoever_shares_the_directory(self, tmp_path):
+        """mkstemp is 0600, but PROCTHOR_RESOURCES_DIR exists to point this
+        somewhere shared -- and an entry nobody else can read is one they
+        regenerate, launching Unity, on every run."""
+        import os
+        import stat
+
+        target = tmp_path / "scene_5.pkl"
+        _interface(5)._write_cache_atomically(self._cache("x"), target)
+
+        umask = os.umask(0o777)
+        os.umask(umask)
+        assert stat.S_IMODE(target.stat().st_mode) == 0o666 & ~umask
+
     def test_an_unreadable_cache_reads_as_a_miss_rather_than_raising(self, tmp_path):
         """Recovers files written before the atomic swap existed."""
         (tmp_path / "scene_9.pkl").write_bytes(b"\x80\x04\x95 truncated garbage")

--- a/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
@@ -90,19 +90,8 @@ class TestTheCacheSurvivesAnInterruptedWrite:
                 thor._write_cache_atomically(self._cache("replacement"), target)
 
         assert thor._load_cache(str(tmp_path)) == self._cache("original")
-
-    def test_an_interrupted_write_leaves_no_debris(self, tmp_path):
-        thor = _interface(5)
-
-        def explode(obj, file):
-            raise KeyboardInterrupt
-
-        with pytest.MonkeyPatch.context() as patch:
-            patch.setattr(pickle, "dump", explode)
-            with pytest.raises(KeyboardInterrupt):
-                thor._write_cache_atomically(self._cache("x"), tmp_path / "scene_5.pkl")
-
-        assert list(tmp_path.iterdir()) == []
+        # And no half-written temporary file left lying beside it.
+        assert [p.name for p in tmp_path.iterdir()] == ["scene_5.pkl"]
 
     def test_an_unreadable_cache_reads_as_a_miss_rather_than_raising(self, tmp_path):
         """Recovers files written before the atomic swap existed."""

--- a/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_cache_dir.py
@@ -60,3 +60,52 @@ def test_an_explicit_path_still_wins(cache_dir, tmp_path):
     somewhere.mkdir()
     (somewhere / "scene_3.pkl").write_bytes(pickle.dumps({"marker": True}))
     assert _interface(3)._load_cache(str(somewhere)) == {"marker": True}
+
+
+class TestTheCacheSurvivesAnInterruptedWrite:
+    """Generating a scene is slow, so it gets interrupted.
+
+    Dumping straight to the destination leaves a truncated pickle that every
+    later run fails to load -- the scene is permanently broken rather than
+    regenerated, and the cache is shared, so one bad file follows the host
+    around.
+    """
+
+    @staticmethod
+    def _cache(marker: str) -> dict:
+        return {"reachable_positions": [], "marker": marker}
+
+    def test_an_interrupted_write_leaves_the_previous_cache_intact(self, tmp_path):
+        thor = _interface(5)
+        target = tmp_path / "scene_5.pkl"
+        thor._write_cache_atomically(self._cache("original"), target)
+
+        def explode(obj, file):
+            file.write(b"\x80\x04\x95truncated")
+            raise KeyboardInterrupt
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(pickle, "dump", explode)
+            with pytest.raises(KeyboardInterrupt):
+                thor._write_cache_atomically(self._cache("replacement"), target)
+
+        assert thor._load_cache(str(tmp_path)) == self._cache("original")
+
+    def test_an_interrupted_write_leaves_no_debris(self, tmp_path):
+        thor = _interface(5)
+
+        def explode(obj, file):
+            raise KeyboardInterrupt
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(pickle, "dump", explode)
+            with pytest.raises(KeyboardInterrupt):
+                thor._write_cache_atomically(self._cache("x"), tmp_path / "scene_5.pkl")
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_an_unreadable_cache_reads_as_a_miss_rather_than_raising(self, tmp_path):
+        """Recovers files written before the atomic swap existed."""
+        (tmp_path / "scene_9.pkl").write_bytes(b"\x80\x04\x95 truncated garbage")
+        with pytest.warns(RuntimeWarning, match="could not be read"):
+            assert _interface(9)._load_cache(str(tmp_path)) is None

--- a/packages/railroad/tests/environment/procthor/test_scene_lock.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_lock.py
@@ -105,3 +105,60 @@ def test_the_lock_is_released_on_exit(tmp_path, timeout):
     for _ in range(3):
         with scene_generation_lock(timeout=timeout, path=lock) as held:
             assert held is True
+
+
+class TestFilesystemsThatCannotLock:
+    """``flock`` fails two very different ways, and only one is worth waiting on.
+
+    ``BlockingIOError`` means another process holds it -- wait. Everything else
+    (``ENOLCK``, ``EOPNOTSUPP``, ``EINVAL``) means this filesystem will never
+    grant it: NFS without lockd, CIFS, some container overlays. Retrying those
+    polls for the entire timeout -- half an hour by default -- while printing
+    that it is waiting on another process. ``PROCTHOR_RESOURCES_DIR`` exists to
+    put the cache somewhere shared, so this is a reachable path, not a theory.
+    """
+
+    @staticmethod
+    def _flock_raising(error: OSError):
+        def flock(fileno, flags):
+            raise error
+        return flock
+
+    def test_an_unsupported_filesystem_fails_open_immediately(
+        self, tmp_path, monkeypatch,
+    ):
+        import errno
+        import fcntl
+
+        monkeypatch.setattr(
+            fcntl, "flock",
+            self._flock_raising(OSError(errno.ENOLCK, "No locks available")),
+        )
+        started = time.monotonic()
+        with scene_generation_lock(
+            timeout=30.0, path=tmp_path / "lock",
+        ) as held:
+            assert held is False
+        # Not "did it eventually give up" -- did it give up without polling.
+        assert time.monotonic() - started < 1.0
+
+    def test_contention_is_still_waited_out(self, tmp_path, monkeypatch):
+        """The retry path must survive the narrowing above."""
+        import fcntl
+
+        calls = []
+        real_flock = fcntl.flock
+
+        def flock(fileno, flags):
+            calls.append(flags)
+            if len(calls) < 3:
+                raise BlockingIOError("busy")
+            return real_flock(fileno, flags)
+
+        monkeypatch.setattr(fcntl, "flock", flock)
+        monkeypatch.setattr(
+            "railroad.environment.procthor._scene_lock.POLL_SECONDS", 0.01,
+        )
+        with scene_generation_lock(timeout=30.0, path=tmp_path / "lock") as held:
+            assert held is True
+        assert len(calls) >= 3

--- a/packages/railroad/tests/environment/procthor/test_scene_lock.py
+++ b/packages/railroad/tests/environment/procthor/test_scene_lock.py
@@ -162,3 +162,15 @@ class TestFilesystemsThatCannotLock:
         with scene_generation_lock(timeout=30.0, path=tmp_path / "lock") as held:
             assert held is True
         assert len(calls) >= 3
+
+
+def test_an_unwritable_resources_directory_fails_open(monkeypatch):
+    """Documented behaviour, but lock_path() creates that directory itself."""
+    from railroad.environment.procthor import _scene_lock
+
+    def unwritable():
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(_scene_lock, "lock_path", unwritable)
+    with scene_generation_lock(timeout=1.0) as held:
+        assert held is False

--- a/packages/railroad/tests/environment/procthor/test_top_down_alignment.py
+++ b/packages/railroad/tests/environment/procthor/test_top_down_alignment.py
@@ -1,32 +1,24 @@
 """Does the ProcTHOR overhead image actually land where we say it does?
 
-One link in the chain cannot be unit-tested: that Unity's ``orthographicSize``
-really is the camera's half-height in world meters, and that it honours the
-rotation we pin. Everything else about the placement is arithmetic, covered in
-``test_top_down_view.py``.
+One link cannot be unit-tested: that Unity's ``orthographicSize`` really is the
+camera's half-height in world meters, and that it honours the rotation we pin.
+Everything else is arithmetic, covered in ``test_top_down_view.py``. This runs
+the whole chain against a rendered scene, using AI2-THOR's reachable positions
+as ground truth -- they are standable floor by construction, so a correct
+placement puts them inside the rendered house.
 
-This checks the whole chain against a rendered scene, using AI2-THOR's own
-reachable positions as ground truth: those are standable floor by construction,
-so projecting them through the recorded extent must land on floor pixels. It
-needs no live controller once the scene is cached, and skips on caches written
-before the extent was recorded -- so it lies dormant until those are
-regenerated, then becomes a real regression test.
-
-Seed choice matters more than it looks. A square, centred house cannot tell a
-correct placement from a transposed or vertically flipped one: seeds 4001 and
-8611 both score 100% *however* the extent is transposed or flipped. These were
-picked by measuring that deliberately wrong placements do drop:
+Seed choice matters. A square, centred house cannot tell a correct placement
+from a transposed or flipped one: 4001 and 8611 score 100% *whatever* you do to
+the extent. These were picked by measuring that wrong placements drop:
 
     seed    correct   transposed   flipped   shifted 0.5m
     7005    100.0%       60.0%      83.4%       98.1%
     8610    100.0%       43.2%      93.4%       90.2%
 
-Seed 1089 is deliberately *not* used. It measures 78.4% while being perfectly
-aligned: a brightly lit pale floor blows out to pure white and joins the skybox
-through a wall that is also white seen from above, so no amount of hole-filling
-separates them. That is a limit of judging placement from pixels, not a
-misalignment -- confirmed by overlaying its reachable positions, which tile its
-floors exactly.
+Seed 1089 is deliberately unused: it measures 78.4% while being perfectly
+aligned, because a lit pale floor blows out to pure white and joins the skybox
+through a wall that is also white from above. A limit of judging placement from
+pixels, not a misalignment.
 """
 
 import numpy as np
@@ -34,50 +26,34 @@ import pytest
 
 from railroad.environment.procthor.thor_interface import ThorInterface
 
-# 7005: 12.7 x 8.5 m, and contains a room the agent cannot reach.
-# 8610:  3.8 x 7.7 m, the strongest discriminator of a transposed placement.
-# 8618: 10.1 x 12.1 m, the strongest discriminator of a flipped one.
+# 7005 contains a room the agent cannot reach; 8610 is the strongest
+# discriminator of a transposed placement, 8618 of a flipped one.
 SEEDS = [7005, 8610, 8618]
 
 SKYBOX_LUMINANCE = 250
-"""At or above this is the white skybox the camera renders around the house.
-
-Testing this per pixel is not enough: seed 1089 has a brightly lit pale floor
-that blows out to pure white over a sixth of its reachable area, so "the pixel
-is white" does not mean "outside the house". The silhouette below fixes that.
-"""
-
-
-def _house_silhouette(image: np.ndarray) -> np.ndarray:
-    """Mask of the house as rendered, interior holes filled.
-
-    The skybox is the only thing outside the house -- the camera renders it
-    white by construction -- so everything darker is scene. Filling holes
-    reclaims interior pixels that merely *look* like skybox: white floors,
-    blown-out highlights, a white tabletop seen from above.
-    """
-    from scipy.ndimage import binary_fill_holes
-
-    return binary_fill_holes(image.astype(int).mean(axis=2) < SKYBOX_LUMINANCE)
+"""At or above this is the white skybox rendered around the house."""
 
 
 def _inside_house_rate(thor: ThorInterface) -> float:
     """Fraction of reachable positions landing inside the rendered house.
 
-    Reachable positions are standable floor by construction, so under a correct
-    placement essentially all of them fall within the silhouette. Under a
-    transposed, flipped or shifted one they spill onto the skybox.
+    Against the house *silhouette* -- non-skybox with interior holes filled --
+    rather than per pixel, so a white floor inside the house does not read as
+    being outside it.
     """
+    from scipy.ndimage import binary_fill_holes
+
     view = thor.get_top_down_view()
     assert view is not None
-    silhouette = _house_silhouette(view.image)
+    silhouette = binary_fill_holes(
+        view.image.astype(int).mean(axis=2) < SKYBOX_LUMINANCE
+    )
     height, width = silhouette.shape
 
-    positions = thor.get_reachable_positions()
     cells = np.array([
-        thor.scale_to_grid_continuous((p["x"], p["z"])) for p in positions
+        thor.scale_to_grid_continuous((p["x"], p["z"]))
+        for p in thor.get_reachable_positions()
     ])
-    # Cell coordinates -> fractional position across the image -> pixel.
     columns = (cells[:, 0] - view.min_x) / (view.max_x - view.min_x) * width
     rows = (cells[:, 1] - view.min_y) / (view.max_y - view.min_y) * height
 
@@ -91,34 +67,22 @@ def _inside_house_rate(thor: ThorInterface) -> float:
     return float((inside_frame & sampled).mean())
 
 
-def _cached_scene_path(seed: int):
-    """Where this seed's cache lives, without loading the scene to ask."""
-    thor = object.__new__(ThorInterface)
-    thor.seed = seed
-    return thor._cache_dir() / f"scene_{seed}.pkl"
-
-
 @pytest.mark.slow
 @pytest.mark.parametrize("seed", SEEDS)
-def test_reachable_positions_land_on_floor(seed: int) -> None:
+def test_reachable_positions_land_inside_the_rendered_house(seed: int) -> None:
     # Check the cache before constructing: ThorInterface launches Unity on a
-    # miss, so an unguarded construction turns "skip, no cache" into a hang or
-    # a hard failure on any machine without a display.
-    if not _cached_scene_path(seed).exists():
-        pytest.skip(
-            f"scene {seed} is not cached; generate it with a display attached "
-            "to enable this test"
-        )
+    # miss, so an unguarded construction turns "skip" into a hang on any
+    # machine without a display.
+    probe = object.__new__(ThorInterface)
+    probe.seed = seed
+    if not (probe._cache_dir() / f"scene_{seed}.pkl").exists():
+        pytest.skip(f"scene {seed} is not cached; generate it with a display")
+
     thor = ThorInterface(seed=seed)
     if thor.get_top_down_view() is None:
-        pytest.skip(
-            f"scene {seed} was cached before the top-down extent was recorded; "
-            "delete the cache directory to regenerate and enable this test"
-        )
+        pytest.skip(f"scene {seed} predates the recorded extent; regenerate it")
+
     rate = _inside_house_rate(thor)
-    # A correct placement measures exactly 100% on these seeds, and the nearest
-    # wrong one (8610 flipped) measures 93.4%, so this sits in clear air rather
-    # than being tuned to squeak past.
-    assert rate > 0.99, (
-        f"only {rate:.1%} of reachable positions land inside the rendered house"
-    )
+    # Correct placement measures exactly 100% on these seeds and the nearest
+    # wrong one 93.4%, so this sits in clear air rather than squeaking past.
+    assert rate > 0.99, f"only {rate:.1%} landed inside the rendered house"

--- a/packages/railroad/tests/environment/procthor/test_top_down_alignment.py
+++ b/packages/railroad/tests/environment/procthor/test_top_down_alignment.py
@@ -1,0 +1,124 @@
+"""Does the ProcTHOR overhead image actually land where we say it does?
+
+One link in the chain cannot be unit-tested: that Unity's ``orthographicSize``
+really is the camera's half-height in world meters, and that it honours the
+rotation we pin. Everything else about the placement is arithmetic, covered in
+``test_top_down_view.py``.
+
+This checks the whole chain against a rendered scene, using AI2-THOR's own
+reachable positions as ground truth: those are standable floor by construction,
+so projecting them through the recorded extent must land on floor pixels. It
+needs no live controller once the scene is cached, and skips on caches written
+before the extent was recorded -- so it lies dormant until those are
+regenerated, then becomes a real regression test.
+
+Seed choice matters more than it looks. A square, centred house cannot tell a
+correct placement from a transposed or vertically flipped one: seeds 4001 and
+8611 both score 100% *however* the extent is transposed or flipped. These were
+picked by measuring that deliberately wrong placements do drop:
+
+    seed    correct   transposed   flipped   shifted 0.5m
+    7005    100.0%       60.0%      83.4%       98.1%
+    8610    100.0%       43.2%      93.4%       90.2%
+
+Seed 1089 is deliberately *not* used. It measures 78.4% while being perfectly
+aligned: a brightly lit pale floor blows out to pure white and joins the skybox
+through a wall that is also white seen from above, so no amount of hole-filling
+separates them. That is a limit of judging placement from pixels, not a
+misalignment -- confirmed by overlaying its reachable positions, which tile its
+floors exactly.
+"""
+
+import numpy as np
+import pytest
+
+from railroad.environment.procthor.thor_interface import ThorInterface
+
+# 7005: 12.7 x 8.5 m, and contains a room the agent cannot reach.
+# 8610:  3.8 x 7.7 m, the strongest discriminator of a transposed placement.
+# 8618: 10.1 x 12.1 m, the strongest discriminator of a flipped one.
+SEEDS = [7005, 8610, 8618]
+
+SKYBOX_LUMINANCE = 250
+"""At or above this is the white skybox the camera renders around the house.
+
+Testing this per pixel is not enough: seed 1089 has a brightly lit pale floor
+that blows out to pure white over a sixth of its reachable area, so "the pixel
+is white" does not mean "outside the house". The silhouette below fixes that.
+"""
+
+
+def _house_silhouette(image: np.ndarray) -> np.ndarray:
+    """Mask of the house as rendered, interior holes filled.
+
+    The skybox is the only thing outside the house -- the camera renders it
+    white by construction -- so everything darker is scene. Filling holes
+    reclaims interior pixels that merely *look* like skybox: white floors,
+    blown-out highlights, a white tabletop seen from above.
+    """
+    from scipy.ndimage import binary_fill_holes
+
+    return binary_fill_holes(image.astype(int).mean(axis=2) < SKYBOX_LUMINANCE)
+
+
+def _inside_house_rate(thor: ThorInterface) -> float:
+    """Fraction of reachable positions landing inside the rendered house.
+
+    Reachable positions are standable floor by construction, so under a correct
+    placement essentially all of them fall within the silhouette. Under a
+    transposed, flipped or shifted one they spill onto the skybox.
+    """
+    view = thor.get_top_down_view()
+    assert view is not None
+    silhouette = _house_silhouette(view.image)
+    height, width = silhouette.shape
+
+    positions = thor.get_reachable_positions()
+    cells = np.array([
+        thor.scale_to_grid_continuous((p["x"], p["z"])) for p in positions
+    ])
+    # Cell coordinates -> fractional position across the image -> pixel.
+    columns = (cells[:, 0] - view.min_x) / (view.max_x - view.min_x) * width
+    rows = (cells[:, 1] - view.min_y) / (view.max_y - view.min_y) * height
+
+    inside_frame = (
+        (columns >= 0) & (columns < width) & (rows >= 0) & (rows < height)
+    )
+    sampled = silhouette[
+        np.clip(rows.astype(int), 0, height - 1),
+        np.clip(columns.astype(int), 0, width - 1),
+    ]
+    return float((inside_frame & sampled).mean())
+
+
+def _cached_scene_path(seed: int):
+    """Where this seed's cache lives, without loading the scene to ask."""
+    thor = object.__new__(ThorInterface)
+    thor.seed = seed
+    return thor._cache_dir() / f"scene_{seed}.pkl"
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("seed", SEEDS)
+def test_reachable_positions_land_on_floor(seed: int) -> None:
+    # Check the cache before constructing: ThorInterface launches Unity on a
+    # miss, so an unguarded construction turns "skip, no cache" into a hang or
+    # a hard failure on any machine without a display.
+    if not _cached_scene_path(seed).exists():
+        pytest.skip(
+            f"scene {seed} is not cached; generate it with a display attached "
+            "to enable this test"
+        )
+    thor = ThorInterface(seed=seed)
+    if thor.get_top_down_view() is None:
+        pytest.skip(
+            f"scene {seed} was cached before the top-down extent was recorded; "
+            "delete the cache directory to regenerate and enable this test"
+        )
+    rate = _inside_house_rate(thor)
+    # A correct placement measures exactly 100% on these seeds, and the nearest
+    # wrong one (8610 flipped) measures 93.4%, so this sits in clear air rather
+    # than being tuned to squeak past.
+    assert rate > 0.99, (
+        f"only {rate:.1%} of reachable positions land inside the rendered house"
+    )

--- a/packages/railroad/tests/environment/procthor/test_top_down_view.py
+++ b/packages/railroad/tests/environment/procthor/test_top_down_view.py
@@ -1,15 +1,9 @@
 """Placing the ProcTHOR overhead image on the occupancy grid.
 
-The scene's top-down image used to live in its own subplot, because nothing
-downstream knew where it sat in world space: the camera pose and
-``orthographicSize`` were computed at render time and discarded, and the pickle
-cache kept only the pixels. Every normal run is a cache hit with no controller,
-so there was nothing left to ask.
-
-The camera parameters are recorded now, in meters, and converted to grid cells
-on the way out. These tests pin the conversion -- especially the half-cell
-convention and the ``origin="upper"`` tuple ordering, which are where this kind
-of thing silently goes half a cell wrong.
+The camera is told what to frame and the footprint is recorded, so a cached
+image can be positioned with no controller running. These pin the conversion
+into grid cells, and the guard that stops an image being drawn where it does
+not belong.
 """
 
 import pickle
@@ -26,13 +20,13 @@ from railroad.environment.procthor.thor_interface import (
     _EXTENT_WARNED,
 )
 
+RESOLUTION = 0.05
+GRID_SHAPE = (69, 47)
+
 
 def _room(corners):
     """A scene-JSON room with the given (x, z) floor polygon."""
     return {"floorPolygon": [{"x": x, "y": 0.0, "z": z} for x, z in corners]}
-
-RESOLUTION = 0.05
-GRID_SHAPE = (69, 47)
 
 
 @pytest.fixture(autouse=True)
@@ -45,7 +39,7 @@ def _forget_warned_seeds():
 
 def _interface(
     *, extent_m=(0.0, 1.0, 0.0, 1.0), offset=(0.0, 0.0), resolution=RESOLUTION,
-    image=None, include_extent=True, seed=7,
+    include_extent=True, seed=7,
 ) -> ThorInterface:
     """A cache-backed ThorInterface without ``__init__``, which loads a scene."""
     thor = object.__new__(ThorInterface)
@@ -64,7 +58,7 @@ def _interface(
     cached = {
         'cache_version': SCENE_CACHE_VERSION,
         'reachable_positions': [],
-        'image_ortho': np.zeros((4, 4, 3), dtype=np.uint8) if image is None else image,
+        'image_ortho': np.zeros((4, 4, 3), dtype=np.uint8),
         'image_persp': None,
     }
     if include_extent:
@@ -73,142 +67,91 @@ def _interface(
     return thor
 
 
-def _grid_covering_extent(offset, resolution, shape):
-    """The world footprint an image covering exactly *shape* cells would have.
+@pytest.mark.parametrize("offset", [(0.0, 0.0), (-1.35, -0.4)])
+def test_an_image_covering_the_grid_gets_the_grid_s_own_extent(offset):
+    """The anchor: half-cell convention, axis order and y flip, at once.
 
-    Cell k spans ``k - 0.5`` to ``k + 0.5``, so the outer edges of an n-cell
-    span sit half a cell beyond the first and last cell centers.
+    An image whose world footprint is exactly the grid's footprint must land on
+    the extent matplotlib infers for the grid itself, so any half-cell slip,
+    swapped axis or flipped y shows up here. Cell k spans k-0.5 to k+0.5. The
+    negative offset covers scenes with ``min_x < 0``, which take their own
+    branch when the grid is built.
     """
-    n_x, n_y = shape
-    return (
-        offset[0] - 0.5 * resolution,
-        offset[0] + (n_x - 0.5) * resolution,
-        offset[1] - 0.5 * resolution,
-        offset[1] + (n_y - 0.5) * resolution,
+    n_x, n_y = GRID_SHAPE
+    # Straight at the conversion, not through get_top_down_view: a real
+    # footprint is square, and a square one cannot cover a 69x47 grid exactly.
+    thor = _interface(offset=offset)
+    covering_the_grid = (
+        offset[0] - 0.5 * RESOLUTION, offset[0] + (n_x - 0.5) * RESOLUTION,
+        offset[1] - 0.5 * RESOLUTION, offset[1] + (n_y - 0.5) * RESOLUTION,
     )
+    view = thor._view_from_extent(np.zeros((4, 4, 3), dtype=np.uint8), covering_the_grid)
+    assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
+    # bottom > top, which is what keeps the y axis increasing downward.
+    assert view.extent[2] > view.extent[3]
+
+    # The extent is stored in meters, so halving the cell size doubles the
+    # cell coordinates it maps to. Storing cells instead would silently
+    # corrupt any run that does not use the default resolution, since the
+    # cache filename does not record one.
+    finer = _interface(offset=offset, resolution=RESOLUTION / 2)
+    assert finer._view_from_extent(
+        np.zeros((4, 4, 3), dtype=np.uint8), covering_the_grid,
+    ).max_x == pytest.approx(2 * view.max_x)
+
+    # scale_to_grid keys g2p_map, so it must keep returning plain ints --
+    # numpy scalars there break every lookup -- and grid_to_world must invert
+    # it, being the inverse this module previously had no name for.
+    assert thor.scale_to_grid(thor.grid_to_world((12, 45))) == (12, 45)
+    assert all(type(c) is int for c in thor.scale_to_grid((0.7, -0.2)))
 
 
-class TestExtentMath:
-    """Meters -> grid cells, independent of where the footprint came from."""
-
-    @staticmethod
-    def _place(extent_m, *, offset=(0.0, 0.0), resolution=RESOLUTION):
-        thor = object.__new__(ThorInterface)
-        thor.grid_resolution = resolution
-        thor.grid_offset = np.array(offset)
-        image = np.zeros((4, 4, 3), dtype=np.uint8)
-        return thor._view_from_extent(image, extent_m)
-
-    def test_an_image_covering_the_grid_gets_the_grid_s_own_extent(self):
-        """The anchor test: half-cell convention, ordering and y flip at once.
-
-        An image whose world footprint is exactly the grid's footprint must
-        land on the extent matplotlib infers for the grid itself,
-        ``(-0.5, n_x - 0.5, n_y - 0.5, -0.5)``. Any half-cell slip, a swapped
-        axis, or a flipped y shows up here.
-        """
-        offset = (0.0, 0.0)
-        view = self._place(
-            _grid_covering_extent(offset, RESOLUTION, GRID_SHAPE), offset=offset,
+def test_the_cache_round_trips_or_is_refused(tmp_path, monkeypatch):
+    """The extent must survive a pickle round trip, and anything untrustworthy
+    must be turned away rather than drawn in the wrong place: written before
+    the extent existed, or framed differently, which is what a changed
+    TOP_DOWN_MARGIN_M looks like on disk. Warned once per seed, since
+    ``save_video`` reaches this every frame.
+    """
+    # Plain floats, not a dataclass: pickling one pins its module path, and
+    # renaming it later would turn every cache on disk into an AttributeError.
+    writer = object.__new__(ThorInterface)
+    writer.seed = 11
+    writer.controller = None
+    extent = (-0.4, 3.9, -0.4, 3.9)
+    writer._render_top_down_from_controller = (  # ty: ignore[invalid-assignment]
+        lambda orthographic=True: (
+            np.zeros((4, 4, 3), dtype=np.uint8), extent if orthographic else None,
         )
-        n_x, n_y = GRID_SHAPE
-        assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
+    )
+    writer._get_reachable_positions_from_controller = lambda: []  # ty: ignore[invalid-assignment]
+    writer._save_and_get_cache(str(tmp_path))
+    with open(tmp_path / "scene_11.pkl", 'rb') as handle:
+        stored = pickle.load(handle)['image_ortho_extent_m']
+    assert isinstance(stored, tuple)
+    assert all(type(value) is float for value in stored)
 
-    def test_the_same_anchor_holds_with_a_negative_grid_offset(self):
-        """Scenes with ``min_x < 0`` take a different branch when the grid is built."""
-        offset = (-1.35, -0.4)
-        view = self._place(
-            _grid_covering_extent(offset, RESOLUTION, GRID_SHAPE), offset=offset,
-        )
-        n_x, n_y = GRID_SHAPE
-        assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
-
-    def test_bottom_is_below_top_so_y_keeps_increasing_downward(self):
-        """``origin="upper"`` draws row 0 at *top*, and row 0 is min z."""
-        left, right, bottom, top = self._place((0.0, 2.0, 0.0, 3.0)).extent
-        assert left < right
-        assert bottom > top
-
-    def test_the_cached_extent_is_meters_so_resolution_rescales_it(self):
-        """The cache filename encodes no resolution; cells would corrupt this."""
-        extent_m = (0.0, 4.0, 0.0, 4.0)
-        coarse = self._place(extent_m, resolution=0.10)
-        fine = self._place(extent_m, resolution=0.05)
-        # Half the cell size covers the same meters in twice as many cells.
-        assert fine.max_x == pytest.approx(2 * coarse.max_x)
-        assert fine.max_y == pytest.approx(2 * coarse.max_y)
-
-
-class TestGridCoordinateHelpers:
-    def test_grid_to_world_inverts_scale_to_grid(self):
-        thor = _interface(offset=(-1.35, 0.4))
-        for cell in [(0, 0), (12, 45), (68, 3)]:
-            assert thor.scale_to_grid(thor.grid_to_world(cell)) == cell
-
-    def test_a_world_point_round_trips_within_half_a_cell(self):
-        thor = _interface(offset=(-1.35, 0.4))
-        point = (0.717, -0.233)
-        back = thor.grid_to_world(thor.scale_to_grid(point))
-        assert back == pytest.approx(point, abs=RESOLUTION / 2)
-
-    def test_scale_to_grid_still_returns_plain_ints(self):
-        """It keys ``g2p_map``; numpy scalars there would break dict lookups."""
-        cell = _interface(offset=(-1.35, 0.4)).scale_to_grid((0.7, -0.2))
-        assert all(isinstance(c, int) and not isinstance(c, np.integer) for c in cell)
-
-    def test_the_continuous_form_is_what_scale_to_grid_rounds(self):
-        thor = _interface(offset=(-1.35, 0.4))
-        point = (0.717, -0.233)
-        exact = thor.scale_to_grid_continuous(point)
-        assert thor.scale_to_grid(point) == (round(exact[0]), round(exact[1]))
-
-
-class TestStaleCache:
-    def test_a_current_cache_is_used(self):
-        thor = _interface()
-        view = thor.get_top_down_view()
-        assert view is not None
-
-    def test_a_cache_without_an_extent_yields_no_view(self):
-        """Better no image than one that can only be drawn misaligned."""
-        thor = _interface(include_extent=False)
-        with pytest.warns(RuntimeWarning, match="cached before the top-down camera"):
-            assert thor.get_top_down_view() is None
-
-    def test_a_cache_framed_differently_is_rejected(self):
-        """The footprint is recomputable, so a disagreeing cache is stale.
-
-        This is what catches a changed ``TOP_DOWN_MARGIN_M``: the pixels on
-        disk cover a different patch of world than the current build would
-        frame, and drawing them anyway would misplace everything.
-        """
-        thor = _interface()
-        cache = thor.cached_data
-        assert cache is not None
-        cache['image_ortho_extent_m'] = tuple(
-            v + 1.0 for v in cache['image_ortho_extent_m']
-        )
-        with pytest.warns(RuntimeWarning, match="was rendered with the footprint"):
-            assert thor.get_top_down_view() is None
-
-    def test_the_warning_names_the_seed_and_the_cache_directory(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(resources, "DEFAULT_RESOURCES_BASE", tmp_path / "elsewhere")
-        thor = _interface(include_extent=False, seed=4001)
+    monkeypatch.setattr(resources, "DEFAULT_RESOURCES_BASE", tmp_path / "elsewhere")
+    for description, thor in [
+        ("no extent recorded", _interface(include_extent=False, seed=4001)),
+        ("framed differently", _interface(seed=4001)),
+    ]:
+        if description == "framed differently":
+            cache = thor.cached_data
+            assert cache is not None
+            cache['image_ortho_extent_m'] = tuple(
+                v + 1.0 for v in cache['image_ortho_extent_m']
+            )
+        _EXTENT_WARNED.clear()
         with pytest.warns(RuntimeWarning) as caught:
-            thor.get_top_down_view()
+            assert thor.get_top_down_view() is None, description
         message = str(caught[0].message)
-        assert "4001" in message
-        assert str(tmp_path / "elsewhere") in message
+        assert "4001" in message and str(tmp_path / "elsewhere") in message
 
-    def test_it_warns_once_per_seed_however_often_it_is_asked(self):
-        """save_video can reach this per frame; one line is the whole point."""
-        thor = _interface(include_extent=False)
-        with pytest.warns(RuntimeWarning):
-            thor.get_top_down_view()
-        with warnings.catch_warnings(record=True) as caught:
+        with warnings.catch_warnings(record=True) as second:
             warnings.simplefilter("always")
             thor.get_top_down_view()
-        assert caught == []
+        assert second == [], f"warned twice for {description}"
 
 
 class _FakeEvent:
@@ -220,9 +163,8 @@ class _FakeEvent:
 class _FakeController:
     """Stands in for Unity, recording the pose the camera was actually given."""
 
-    def __init__(self, *, rotation, scene_size=(4.0, 3.0), frame_shape=(480, 480)):
+    def __init__(self, *, rotation, frame_shape=(480, 480)):
         self._rotation = rotation
-        self._scene_size = scene_size
         self._frame_shape = frame_shape
         self.camera_pose: dict = {}
 
@@ -234,22 +176,19 @@ class _FakeController:
                     "rotation": dict(self._rotation),
                     "orthographicSize": 1.0,
                 },
-                "sceneBounds": {
-                    "size": {"x": self._scene_size[0], "y": 3.0, "z": self._scene_size[1]},
-                },
+                "sceneBounds": {"size": {"x": 4.0, "y": 3.0, "z": 3.0}},
             })
         assert action == "AddThirdPartyCamera"
         kwargs.pop("skyboxColor", None)
         kwargs.pop("raise_for_failure", None)
         self.camera_pose = kwargs
         height, width = self._frame_shape
-        frame = np.zeros((height, width, 3), dtype=np.uint8)
-        return _FakeEvent({}, frames=[frame])
+        return _FakeEvent({}, frames=[np.zeros((height, width, 3), dtype=np.uint8)])
 
 
-def _controller_backed(controller, seed=5) -> ThorInterface:
+def _controller_backed(controller) -> ThorInterface:
     thor = object.__new__(ThorInterface)
-    thor.seed = seed
+    thor.seed = 5
     thor.controller = controller
     thor.cached_data = None
     thor.grid_resolution = RESOLUTION
@@ -258,110 +197,55 @@ def _controller_backed(controller, seed=5) -> ThorInterface:
     return thor
 
 
-class TestFootprint:
-    """The framing is ours, computed from the scene JSON, not THOR's.
+def test_the_camera_frames_our_footprint_not_thor_s():
+    """THOR frames on ``sceneBounds``, which is not reconstructible offline.
 
-    AI2-THOR frames its map view on ``sceneBounds`` -- the union of every
-    enabled renderer -- which includes geometry invisible from above and is
-    inconsistent enough across ProcTHOR-10k to be an open upstream bug
-    (allenai/ai2thor#1181). Choosing the footprint here is what makes it
-    knowable without a live controller.
+    So the camera is told where to look and how much to cover, and the extent
+    reported back is exactly that. sceneBounds still sets the camera *height*,
+    which cannot skew an orthographic footprint.
     """
+    controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
+    thor = _controller_backed(controller)
+    _image, extent = thor._render_top_down_from_controller()
 
-    def test_the_footprint_squares_up_the_room_polygons_plus_a_margin(self):
-        thor = object.__new__(ThorInterface)
-        thor.rooms = [_room([(1.0, 2.0), (9.0, 2.0), (9.0, 6.0), (1.0, 6.0)])]
-        min_x, max_x, min_z, max_z = thor.top_down_footprint()
-        half = 0.5 * 8.0 + TOP_DOWN_MARGIN_M  # the longer span wins
-        assert (min_x, max_x) == pytest.approx((5.0 - half, 5.0 + half))
-        assert (min_z, max_z) == pytest.approx((4.0 - half, 4.0 + half))
+    assert extent is not None
+    assert extent == pytest.approx(thor.top_down_footprint())
 
-    def test_it_covers_rooms_the_agent_cannot_reach(self):
-        """Framing on reachable space would crop a sealed room out entirely."""
-        thor = object.__new__(ThorInterface)
-        thor.rooms = [
-            _room([(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]),
-            _room([(0.0, 4.0), (4.0, 4.0), (4.0, 9.0), (0.0, 9.0)]),
-        ]
-        min_x, max_x, min_z, max_z = thor.top_down_footprint()
-        assert min_z <= 0.0 and max_z >= 9.0
-        assert min_x <= 0.0 and max_x >= 4.0
-
-
-class TestCameraSetup:
-    def test_the_camera_is_pinned_straight_down(self):
-        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
-        _controller_backed(controller)._render_top_down_from_controller()
-        assert controller.camera_pose["rotation"] == {"x": 90.0, "y": 0.0, "z": 0.0}
-
-    def test_a_yawed_map_view_is_overridden_and_reported(self):
-        """A yaw would skew the footprint into something no extent can express."""
-        controller = _FakeController(rotation={"x": 90.0, "y": 35.0, "z": 0.0})
-        thor = _controller_backed(controller, seed=4001)
-        with pytest.warns(RuntimeWarning, match="rotation"):
-            thor._render_top_down_from_controller()
-        assert controller.camera_pose["rotation"] == {"x": 90.0, "y": 0.0, "z": 0.0}
-
-    def test_the_camera_is_placed_on_our_footprint_not_thor_s(self):
-        """The reported extent must be exactly what the camera was told to frame."""
-        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
-        thor = _controller_backed(controller)
-        _image, extent = thor._render_top_down_from_controller()
-
-        assert extent is not None
-        assert extent == pytest.approx(thor.top_down_footprint())
-        min_x, max_x, min_z, max_z = extent
-        pose = controller.camera_pose
-        assert pose["position"]["x"] == pytest.approx(0.5 * (min_x + max_x))
-        assert pose["position"]["z"] == pytest.approx(0.5 * (min_z + max_z))
-        assert pose["orthographicSize"] == pytest.approx(0.5 * (max_z - min_z))
-        # THOR's own framing must not leak into the horizontal placement.
-        assert pose["position"]["x"] != pytest.approx(1.5)
-
-    def test_the_scene_bounds_still_set_the_camera_height(self):
-        """Height cannot skew an orthographic footprint, so THOR's value is fine."""
-        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0},
-                                     scene_size=(4.0, 3.0))
-        _controller_backed(controller)._render_top_down_from_controller()
-        assert controller.camera_pose["position"]["y"] == pytest.approx(2.0 + 1.1 * 4.0)
-
-    def test_a_non_square_frame_is_refused_rather_than_skewed(self):
-        """A square footprint is only right for a square frame."""
-        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0},
-                                     frame_shape=(480, 640))
-        with pytest.raises(RuntimeError, match="square"):
-            _controller_backed(controller)._render_top_down_from_controller()
-
-    def test_the_perspective_render_reports_no_footprint(self):
-        """A projective view has no rectangular footprint to report."""
-        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
-        _image, extent = _controller_backed(controller)._render_top_down_from_controller(
-            orthographic=False
-        )
-        assert extent is None
+    # That footprint squares up the room polygons plus a margin -- framed on
+    # the rooms, not on reachable space, since seeds 7005 and 8619 contain
+    # rooms the agent cannot enter and framing on where it can walk would crop
+    # them out of the picture entirely.
+    thor.rooms = [
+        _room([(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]),
+        _room([(0.0, 4.0), (4.0, 4.0), (4.0, 9.0), (0.0, 9.0)]),  # unreachable
+    ]
+    half = 0.5 * 9.0 + TOP_DOWN_MARGIN_M  # the longer span wins
+    assert thor.top_down_footprint() == pytest.approx(
+        (2.0 - half, 2.0 + half, 4.5 - half, 4.5 + half)
+    )
+    min_x, max_x, min_z, max_z = extent
+    pose = controller.camera_pose
+    assert pose["position"]["x"] == pytest.approx(0.5 * (min_x + max_x))
+    assert pose["position"]["z"] == pytest.approx(0.5 * (min_z + max_z))
+    assert pose["orthographicSize"] == pytest.approx(0.5 * (max_z - min_z))
+    assert pose["position"]["y"] == pytest.approx(2.0 + 1.1 * 4.0)
+    # A projective view has no rectangular footprint to report.
+    assert thor._render_top_down_from_controller(orthographic=False)[1] is None
 
 
-class TestCacheFormat:
-    def test_a_written_cache_stores_the_extent_as_plain_floats(self, tmp_path):
-        """Not a dataclass: pickling one pins its module path forever."""
-        thor = object.__new__(ThorInterface)
-        thor.seed = 11
-        # Never used: both controller-touching calls are stubbed out below.
-        thor.controller = None
-        extent = (-0.4, 3.9, -0.4, 3.9)
-        thor._render_top_down_from_controller = (  # ty: ignore[invalid-assignment]
-            lambda orthographic=True: (
-                np.zeros((4, 4, 3), dtype=np.uint8), extent if orthographic else None,
-            )
-        )
-        thor._get_reachable_positions_from_controller = lambda: []  # ty: ignore[invalid-assignment]
+def test_a_camera_that_cannot_be_mapped_is_refused_rather_than_skewed():
+    """Both of these would misplace every overlay while looking plausible.
 
-        cache = thor._save_and_get_cache(str(tmp_path))
-        assert cache['cache_version'] == SCENE_CACHE_VERSION
-        assert cache['image_ortho_extent_m'] == extent
+    A yaw rotates the footprint out of axis-alignment, which no rectangular
+    extent can express; a non-square frame stretches one axis against a square
+    footprint.
+    """
+    yawed = _FakeController(rotation={"x": 90.0, "y": 35.0, "z": 0.0})
+    with pytest.warns(RuntimeWarning, match="rotation"):
+        _controller_backed(yawed)._render_top_down_from_controller()
+    assert yawed.camera_pose["rotation"] == {"x": 90.0, "y": 0.0, "z": 0.0}
 
-        with open(tmp_path / "scene_11.pkl", 'rb') as handle:
-            reloaded = pickle.load(handle)
-        stored = reloaded['image_ortho_extent_m']
-        assert isinstance(stored, tuple)
-        assert all(type(value) is float for value in stored)
+    oblong = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0},
+                             frame_shape=(480, 640))
+    with pytest.raises(RuntimeError, match="square"):
+        _controller_backed(oblong)._render_top_down_from_controller()

--- a/packages/railroad/tests/environment/procthor/test_top_down_view.py
+++ b/packages/railroad/tests/environment/procthor/test_top_down_view.py
@@ -15,6 +15,7 @@ import pytest
 from railroad.environment.procthor import resources
 from railroad.environment.procthor.thor_interface import (
     SCENE_CACHE_VERSION,
+    _decode_image,
     TOP_DOWN_MARGIN_M,
     ThorInterface,
     _EXTENT_WARNED,
@@ -127,9 +128,13 @@ def test_the_cache_round_trips_or_is_refused(tmp_path, monkeypatch):
     writer._get_reachable_positions_from_controller = lambda: []  # ty: ignore[invalid-assignment]
     writer._save_and_get_cache(str(tmp_path))
     with open(tmp_path / "scene_11.pkl", 'rb') as handle:
-        stored = pickle.load(handle)['image_ortho_extent_m']
+        written = pickle.load(handle)
+    stored = written['image_ortho_extent_m']
     assert isinstance(stored, tuple)
     assert all(type(value) is float for value in stored)
+    # JPEG, since a 2048 render is ~50x this size raw.
+    assert isinstance(written['image_ortho'], bytes)
+    assert _decode_image(written['image_ortho']).shape == (4, 4, 3)
 
     monkeypatch.setattr(resources, "DEFAULT_RESOURCES_BASE", tmp_path / "elsewhere")
     for description, thor in [

--- a/packages/railroad/tests/environment/procthor/test_top_down_view.py
+++ b/packages/railroad/tests/environment/procthor/test_top_down_view.py
@@ -1,0 +1,367 @@
+"""Placing the ProcTHOR overhead image on the occupancy grid.
+
+The scene's top-down image used to live in its own subplot, because nothing
+downstream knew where it sat in world space: the camera pose and
+``orthographicSize`` were computed at render time and discarded, and the pickle
+cache kept only the pixels. Every normal run is a cache hit with no controller,
+so there was nothing left to ask.
+
+The camera parameters are recorded now, in meters, and converted to grid cells
+on the way out. These tests pin the conversion -- especially the half-cell
+convention and the ``origin="upper"`` tuple ordering, which are where this kind
+of thing silently goes half a cell wrong.
+"""
+
+import pickle
+import warnings
+
+import numpy as np
+import pytest
+
+from railroad.environment.procthor import resources
+from railroad.environment.procthor.thor_interface import (
+    SCENE_CACHE_VERSION,
+    TOP_DOWN_MARGIN_M,
+    ThorInterface,
+    _EXTENT_WARNED,
+)
+
+
+def _room(corners):
+    """A scene-JSON room with the given (x, z) floor polygon."""
+    return {"floorPolygon": [{"x": x, "y": 0.0, "z": z} for x, z in corners]}
+
+RESOLUTION = 0.05
+GRID_SHAPE = (69, 47)
+
+
+@pytest.fixture(autouse=True)
+def _forget_warned_seeds():
+    """The once-per-seed warning guard is module state; keep tests independent."""
+    _EXTENT_WARNED.clear()
+    yield
+    _EXTENT_WARNED.clear()
+
+
+def _interface(
+    *, extent_m=(0.0, 1.0, 0.0, 1.0), offset=(0.0, 0.0), resolution=RESOLUTION,
+    image=None, include_extent=True, seed=7,
+) -> ThorInterface:
+    """A cache-backed ThorInterface without ``__init__``, which loads a scene."""
+    thor = object.__new__(ThorInterface)
+    thor.seed = seed
+    thor.grid_resolution = resolution
+    thor.grid_offset = np.array(offset)
+    thor.controller = None
+    # Rooms whose footprint is exactly extent_m, so the cache reads as current
+    # unless a test deliberately makes it disagree.
+    min_x, max_x, min_z, max_z = extent_m
+    inset = TOP_DOWN_MARGIN_M
+    thor.rooms = [_room([
+        (min_x + inset, min_z + inset), (max_x - inset, min_z + inset),
+        (max_x - inset, max_z - inset), (min_x + inset, max_z - inset),
+    ])]
+    cached = {
+        'cache_version': SCENE_CACHE_VERSION,
+        'reachable_positions': [],
+        'image_ortho': np.zeros((4, 4, 3), dtype=np.uint8) if image is None else image,
+        'image_persp': None,
+    }
+    if include_extent:
+        cached['image_ortho_extent_m'] = extent_m
+    thor.cached_data = cached
+    return thor
+
+
+def _grid_covering_extent(offset, resolution, shape):
+    """The world footprint an image covering exactly *shape* cells would have.
+
+    Cell k spans ``k - 0.5`` to ``k + 0.5``, so the outer edges of an n-cell
+    span sit half a cell beyond the first and last cell centers.
+    """
+    n_x, n_y = shape
+    return (
+        offset[0] - 0.5 * resolution,
+        offset[0] + (n_x - 0.5) * resolution,
+        offset[1] - 0.5 * resolution,
+        offset[1] + (n_y - 0.5) * resolution,
+    )
+
+
+class TestExtentMath:
+    """Meters -> grid cells, independent of where the footprint came from."""
+
+    @staticmethod
+    def _place(extent_m, *, offset=(0.0, 0.0), resolution=RESOLUTION):
+        thor = object.__new__(ThorInterface)
+        thor.grid_resolution = resolution
+        thor.grid_offset = np.array(offset)
+        image = np.zeros((4, 4, 3), dtype=np.uint8)
+        return thor._view_from_extent(image, extent_m)
+
+    def test_an_image_covering_the_grid_gets_the_grid_s_own_extent(self):
+        """The anchor test: half-cell convention, ordering and y flip at once.
+
+        An image whose world footprint is exactly the grid's footprint must
+        land on the extent matplotlib infers for the grid itself,
+        ``(-0.5, n_x - 0.5, n_y - 0.5, -0.5)``. Any half-cell slip, a swapped
+        axis, or a flipped y shows up here.
+        """
+        offset = (0.0, 0.0)
+        view = self._place(
+            _grid_covering_extent(offset, RESOLUTION, GRID_SHAPE), offset=offset,
+        )
+        n_x, n_y = GRID_SHAPE
+        assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
+
+    def test_the_same_anchor_holds_with_a_negative_grid_offset(self):
+        """Scenes with ``min_x < 0`` take a different branch when the grid is built."""
+        offset = (-1.35, -0.4)
+        view = self._place(
+            _grid_covering_extent(offset, RESOLUTION, GRID_SHAPE), offset=offset,
+        )
+        n_x, n_y = GRID_SHAPE
+        assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
+
+    def test_bottom_is_below_top_so_y_keeps_increasing_downward(self):
+        """``origin="upper"`` draws row 0 at *top*, and row 0 is min z."""
+        left, right, bottom, top = self._place((0.0, 2.0, 0.0, 3.0)).extent
+        assert left < right
+        assert bottom > top
+
+    def test_the_cached_extent_is_meters_so_resolution_rescales_it(self):
+        """The cache filename encodes no resolution; cells would corrupt this."""
+        extent_m = (0.0, 4.0, 0.0, 4.0)
+        coarse = self._place(extent_m, resolution=0.10)
+        fine = self._place(extent_m, resolution=0.05)
+        # Half the cell size covers the same meters in twice as many cells.
+        assert fine.max_x == pytest.approx(2 * coarse.max_x)
+        assert fine.max_y == pytest.approx(2 * coarse.max_y)
+
+
+class TestGridCoordinateHelpers:
+    def test_grid_to_world_inverts_scale_to_grid(self):
+        thor = _interface(offset=(-1.35, 0.4))
+        for cell in [(0, 0), (12, 45), (68, 3)]:
+            assert thor.scale_to_grid(thor.grid_to_world(cell)) == cell
+
+    def test_a_world_point_round_trips_within_half_a_cell(self):
+        thor = _interface(offset=(-1.35, 0.4))
+        point = (0.717, -0.233)
+        back = thor.grid_to_world(thor.scale_to_grid(point))
+        assert back == pytest.approx(point, abs=RESOLUTION / 2)
+
+    def test_scale_to_grid_still_returns_plain_ints(self):
+        """It keys ``g2p_map``; numpy scalars there would break dict lookups."""
+        cell = _interface(offset=(-1.35, 0.4)).scale_to_grid((0.7, -0.2))
+        assert all(isinstance(c, int) and not isinstance(c, np.integer) for c in cell)
+
+    def test_the_continuous_form_is_what_scale_to_grid_rounds(self):
+        thor = _interface(offset=(-1.35, 0.4))
+        point = (0.717, -0.233)
+        exact = thor.scale_to_grid_continuous(point)
+        assert thor.scale_to_grid(point) == (round(exact[0]), round(exact[1]))
+
+
+class TestStaleCache:
+    def test_a_current_cache_is_used(self):
+        thor = _interface()
+        view = thor.get_top_down_view()
+        assert view is not None
+
+    def test_a_cache_without_an_extent_yields_no_view(self):
+        """Better no image than one that can only be drawn misaligned."""
+        thor = _interface(include_extent=False)
+        with pytest.warns(RuntimeWarning, match="cached before the top-down camera"):
+            assert thor.get_top_down_view() is None
+
+    def test_a_cache_framed_differently_is_rejected(self):
+        """The footprint is recomputable, so a disagreeing cache is stale.
+
+        This is what catches a changed ``TOP_DOWN_MARGIN_M``: the pixels on
+        disk cover a different patch of world than the current build would
+        frame, and drawing them anyway would misplace everything.
+        """
+        thor = _interface()
+        cache = thor.cached_data
+        assert cache is not None
+        cache['image_ortho_extent_m'] = tuple(
+            v + 1.0 for v in cache['image_ortho_extent_m']
+        )
+        with pytest.warns(RuntimeWarning, match="was rendered with the footprint"):
+            assert thor.get_top_down_view() is None
+
+    def test_the_warning_names_the_seed_and_the_cache_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(resources, "DEFAULT_RESOURCES_BASE", tmp_path / "elsewhere")
+        thor = _interface(include_extent=False, seed=4001)
+        with pytest.warns(RuntimeWarning) as caught:
+            thor.get_top_down_view()
+        message = str(caught[0].message)
+        assert "4001" in message
+        assert str(tmp_path / "elsewhere") in message
+
+    def test_it_warns_once_per_seed_however_often_it_is_asked(self):
+        """save_video can reach this per frame; one line is the whole point."""
+        thor = _interface(include_extent=False)
+        with pytest.warns(RuntimeWarning):
+            thor.get_top_down_view()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            thor.get_top_down_view()
+        assert caught == []
+
+
+class _FakeEvent:
+    def __init__(self, metadata, frames=()):
+        self.metadata = metadata
+        self.third_party_camera_frames = list(frames)
+
+
+class _FakeController:
+    """Stands in for Unity, recording the pose the camera was actually given."""
+
+    def __init__(self, *, rotation, scene_size=(4.0, 3.0), frame_shape=(480, 480)):
+        self._rotation = rotation
+        self._scene_size = scene_size
+        self._frame_shape = frame_shape
+        self.camera_pose: dict = {}
+
+    def step(self, action, **kwargs):
+        if action == "GetMapViewCameraProperties":
+            return _FakeEvent({
+                "actionReturn": {
+                    "position": {"x": 1.5, "y": 2.0, "z": -0.5},
+                    "rotation": dict(self._rotation),
+                    "orthographicSize": 1.0,
+                },
+                "sceneBounds": {
+                    "size": {"x": self._scene_size[0], "y": 3.0, "z": self._scene_size[1]},
+                },
+            })
+        assert action == "AddThirdPartyCamera"
+        kwargs.pop("skyboxColor", None)
+        kwargs.pop("raise_for_failure", None)
+        self.camera_pose = kwargs
+        height, width = self._frame_shape
+        frame = np.zeros((height, width, 3), dtype=np.uint8)
+        return _FakeEvent({}, frames=[frame])
+
+
+def _controller_backed(controller, seed=5) -> ThorInterface:
+    thor = object.__new__(ThorInterface)
+    thor.seed = seed
+    thor.controller = controller
+    thor.cached_data = None
+    thor.grid_resolution = RESOLUTION
+    thor.grid_offset = np.array((0.0, 0.0))
+    thor.rooms = [_room([(0.0, 0.0), (6.0, 0.0), (6.0, 4.0), (0.0, 4.0)])]
+    return thor
+
+
+class TestFootprint:
+    """The framing is ours, computed from the scene JSON, not THOR's.
+
+    AI2-THOR frames its map view on ``sceneBounds`` -- the union of every
+    enabled renderer -- which includes geometry invisible from above and is
+    inconsistent enough across ProcTHOR-10k to be an open upstream bug
+    (allenai/ai2thor#1181). Choosing the footprint here is what makes it
+    knowable without a live controller.
+    """
+
+    def test_the_footprint_squares_up_the_room_polygons_plus_a_margin(self):
+        thor = object.__new__(ThorInterface)
+        thor.rooms = [_room([(1.0, 2.0), (9.0, 2.0), (9.0, 6.0), (1.0, 6.0)])]
+        min_x, max_x, min_z, max_z = thor.top_down_footprint()
+        half = 0.5 * 8.0 + TOP_DOWN_MARGIN_M  # the longer span wins
+        assert (min_x, max_x) == pytest.approx((5.0 - half, 5.0 + half))
+        assert (min_z, max_z) == pytest.approx((4.0 - half, 4.0 + half))
+
+    def test_it_covers_rooms_the_agent_cannot_reach(self):
+        """Framing on reachable space would crop a sealed room out entirely."""
+        thor = object.__new__(ThorInterface)
+        thor.rooms = [
+            _room([(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0)]),
+            _room([(0.0, 4.0), (4.0, 4.0), (4.0, 9.0), (0.0, 9.0)]),
+        ]
+        min_x, max_x, min_z, max_z = thor.top_down_footprint()
+        assert min_z <= 0.0 and max_z >= 9.0
+        assert min_x <= 0.0 and max_x >= 4.0
+
+
+class TestCameraSetup:
+    def test_the_camera_is_pinned_straight_down(self):
+        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
+        _controller_backed(controller)._render_top_down_from_controller()
+        assert controller.camera_pose["rotation"] == {"x": 90.0, "y": 0.0, "z": 0.0}
+
+    def test_a_yawed_map_view_is_overridden_and_reported(self):
+        """A yaw would skew the footprint into something no extent can express."""
+        controller = _FakeController(rotation={"x": 90.0, "y": 35.0, "z": 0.0})
+        thor = _controller_backed(controller, seed=4001)
+        with pytest.warns(RuntimeWarning, match="rotation"):
+            thor._render_top_down_from_controller()
+        assert controller.camera_pose["rotation"] == {"x": 90.0, "y": 0.0, "z": 0.0}
+
+    def test_the_camera_is_placed_on_our_footprint_not_thor_s(self):
+        """The reported extent must be exactly what the camera was told to frame."""
+        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
+        thor = _controller_backed(controller)
+        _image, extent = thor._render_top_down_from_controller()
+
+        assert extent is not None
+        assert extent == pytest.approx(thor.top_down_footprint())
+        min_x, max_x, min_z, max_z = extent
+        pose = controller.camera_pose
+        assert pose["position"]["x"] == pytest.approx(0.5 * (min_x + max_x))
+        assert pose["position"]["z"] == pytest.approx(0.5 * (min_z + max_z))
+        assert pose["orthographicSize"] == pytest.approx(0.5 * (max_z - min_z))
+        # THOR's own framing must not leak into the horizontal placement.
+        assert pose["position"]["x"] != pytest.approx(1.5)
+
+    def test_the_scene_bounds_still_set_the_camera_height(self):
+        """Height cannot skew an orthographic footprint, so THOR's value is fine."""
+        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0},
+                                     scene_size=(4.0, 3.0))
+        _controller_backed(controller)._render_top_down_from_controller()
+        assert controller.camera_pose["position"]["y"] == pytest.approx(2.0 + 1.1 * 4.0)
+
+    def test_a_non_square_frame_is_refused_rather_than_skewed(self):
+        """A square footprint is only right for a square frame."""
+        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0},
+                                     frame_shape=(480, 640))
+        with pytest.raises(RuntimeError, match="square"):
+            _controller_backed(controller)._render_top_down_from_controller()
+
+    def test_the_perspective_render_reports_no_footprint(self):
+        """A projective view has no rectangular footprint to report."""
+        controller = _FakeController(rotation={"x": 90.0, "y": 0.0, "z": 0.0})
+        _image, extent = _controller_backed(controller)._render_top_down_from_controller(
+            orthographic=False
+        )
+        assert extent is None
+
+
+class TestCacheFormat:
+    def test_a_written_cache_stores_the_extent_as_plain_floats(self, tmp_path):
+        """Not a dataclass: pickling one pins its module path forever."""
+        thor = object.__new__(ThorInterface)
+        thor.seed = 11
+        # Never used: both controller-touching calls are stubbed out below.
+        thor.controller = None
+        extent = (-0.4, 3.9, -0.4, 3.9)
+        thor._render_top_down_from_controller = (  # ty: ignore[invalid-assignment]
+            lambda orthographic=True: (
+                np.zeros((4, 4, 3), dtype=np.uint8), extent if orthographic else None,
+            )
+        )
+        thor._get_reachable_positions_from_controller = lambda: []  # ty: ignore[invalid-assignment]
+
+        cache = thor._save_and_get_cache(str(tmp_path))
+        assert cache['cache_version'] == SCENE_CACHE_VERSION
+        assert cache['image_ortho_extent_m'] == extent
+
+        with open(tmp_path / "scene_11.pkl", 'rb') as handle:
+            reloaded = pickle.load(handle)
+        stored = reloaded['image_ortho_extent_m']
+        assert isinstance(stored, tuple)
+        assert all(type(value) is float for value in stored)

--- a/packages/railroad/tests/environment/railsim/test_maps.py
+++ b/packages/railroad/tests/environment/railsim/test_maps.py
@@ -72,25 +72,20 @@ def test_top_down_view_is_transposed_to_match_the_plot(maze_scene: RailsimScene)
     """``get_top_down_image`` is indexed [x, y]; the plot draws ``grid.T``.
 
     That mismatch was invisible while the image had its own subplot. Drawn
-    underneath the trajectory it would render a mirrored map, so the view
-    transposes and the test pins which way round it ends up.
+    underneath the trajectory it renders a mirrored map, so the view transposes
+    -- and its extent is the one imshow would infer for the grid itself, since
+    it is exactly one pixel per cell.
     """
     view = maze_scene.get_top_down_view()
     n_x, n_y = maze_scene.raw_grid.shape
     assert view.image.shape == (n_y, n_x, 3)
+    assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
 
     raw = maze_scene.get_top_down_image()
     occupied = np.argwhere(maze_scene.raw_grid >= 0.5)
     free = np.argwhere(maze_scene.raw_grid < 0.5)
     for i, j in (occupied[len(occupied) // 2], free[len(free) // 2]):
         np.testing.assert_array_equal(view.image[j, i], raw[i, j])
-
-
-def test_top_down_view_covers_exactly_the_grid(maze_scene: RailsimScene) -> None:
-    """One pixel per cell, so it lands on the extent imshow infers for the grid."""
-    view = maze_scene.get_top_down_view()
-    n_x, n_y = maze_scene.grid.shape
-    assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
 
 
 def test_seeded_generation_is_deterministic() -> None:

--- a/packages/railroad/tests/environment/railsim/test_maps.py
+++ b/packages/railroad/tests/environment/railsim/test_maps.py
@@ -68,6 +68,31 @@ def test_top_down_image(maze_scene: RailsimScene) -> None:
     assert image.dtype == np.uint8
 
 
+def test_top_down_view_is_transposed_to_match_the_plot(maze_scene: RailsimScene) -> None:
+    """``get_top_down_image`` is indexed [x, y]; the plot draws ``grid.T``.
+
+    That mismatch was invisible while the image had its own subplot. Drawn
+    underneath the trajectory it would render a mirrored map, so the view
+    transposes and the test pins which way round it ends up.
+    """
+    view = maze_scene.get_top_down_view()
+    n_x, n_y = maze_scene.raw_grid.shape
+    assert view.image.shape == (n_y, n_x, 3)
+
+    raw = maze_scene.get_top_down_image()
+    occupied = np.argwhere(maze_scene.raw_grid >= 0.5)
+    free = np.argwhere(maze_scene.raw_grid < 0.5)
+    for i, j in (occupied[len(occupied) // 2], free[len(free) // 2]):
+        np.testing.assert_array_equal(view.image[j, i], raw[i, j])
+
+
+def test_top_down_view_covers_exactly_the_grid(maze_scene: RailsimScene) -> None:
+    """One pixel per cell, so it lands on the extent imshow infers for the grid."""
+    view = maze_scene.get_top_down_view()
+    n_x, n_y = maze_scene.grid.shape
+    assert view.extent == pytest.approx((-0.5, n_x - 0.5, n_y - 0.5, -0.5))
+
+
 def test_seeded_generation_is_deterministic() -> None:
     a = RailsimScene.maze(seed=99, config=SMALL_MAZE)
     b = RailsimScene.maze(seed=99, config=SMALL_MAZE)

--- a/packages/railroad/tests/test_dashboard_overhead.py
+++ b/packages/railroad/tests/test_dashboard_overhead.py
@@ -1,15 +1,9 @@
 """Drawing the scene's overhead image underneath the trajectory.
 
-The overhead image used to occupy its own column of the figure, alongside an
-occupancy-grid trajectory panel it could not be registered against. Now that
-scenes report where their image sits, it goes underneath the trajectory in the
-main axes and the extra column is gone.
-
-These tests use a synthetic scene rather than ProcTHOR or railsim, so they say
-nothing about whether a *particular* scene's extent is right -- that belongs to
-the providers' own tests -- only that the dashboard wires it up in the right
-order, with the right limits, and degrades to a plain grid when a scene cannot
-place its image.
+A synthetic scene throughout, so these say nothing about whether a *particular*
+scene's extent is right -- that belongs to the providers' own tests -- only
+that the dashboard wires it up in the right order, with the right limits, and
+degrades to a plain grid when a scene cannot place its image.
 """
 
 import matplotlib
@@ -87,23 +81,38 @@ def _layer(ax, zorder):
 
 
 class TestPhotoUnderlay:
-    def test_the_image_is_drawn_below_the_grid(self):
+    @pytest.mark.parametrize("scene", [None, "photo"])
+    def test_the_figure_is_just_the_main_axes_and_a_sidebar(self, scene):
+        """The image moved under the trajectory, so its own column is gone."""
+        db, coords = _dashboard(_Scene(_photo_view()) if scene else None)
+        figure, _ax = _main_axes(db, coords)
+        assert len(figure.axes) == 2
+
+    def test_a_known_map_gets_the_image_alone_beneath_the_trajectory(self):
+        """Nothing for the grid or the outline to add once it is all observed.
+
+        The image still has to sit *under* the grid rather than over it, or it
+        would hide the very thing it is drawn beneath.
+        """
         db, coords = _dashboard(_Scene(_photo_view()))
         _figure, ax = _main_axes(db, coords)
+
         photo, grid = _layer(ax, -1), _layer(ax, 0)
         assert photo is not None and grid is not None
         assert photo.get_zorder() < grid.get_zorder()
-        left, right, bottom, top = photo.get_extent()
-        assert (left, right, bottom, top) == pytest.approx((
+        assert photo.get_extent() == pytest.approx((
             PHOTO_EXTENT["min_x"], PHOTO_EXTENT["max_x"],
             PHOTO_EXTENT["max_y"], PHOTO_EXTENT["min_y"],
         ))
 
-    def test_the_grid_vanishes_over_an_image_when_the_map_is_known(self):
-        """With the whole map known, the image says everything the grid does."""
-        db, coords = _dashboard(_Scene(_photo_view()))
+        assert np.asarray(grid.get_alpha()).max() == pytest.approx(0.0)
+        outline = _layer(ax, 0.5)
+        assert outline is None or np.asarray(outline.get_array())[:, :, 3].max() == 0
+
+        # Without an image the grid is opaque again, since it is all there is.
+        db, coords = _dashboard(None)
         _figure, ax = _main_axes(db, coords)
-        assert np.asarray(_layer(ax, 0).get_alpha()).max() == pytest.approx(0.0)
+        assert _layer(ax, 0).get_alpha() is None
 
     def test_how_far_the_robot_has_seen_is_outlined_not_shaded(self):
         """The one thing an image cannot show is where the robot has not looked.
@@ -118,28 +127,30 @@ class TestPhotoUnderlay:
         assert outline is not None, "no known-region outline drawn"
         opacity = np.asarray(outline.get_array())[:, :, 3]
         assert opacity.max() > 0.5, "outline is invisible"
-        # An outline, not a wash: only a thin border is painted at all.
-        assert (opacity > 0).mean() < 0.2
+        assert (opacity > 0).mean() < 0.2, "outline has become a wash"
 
-    def test_a_fully_known_map_gets_no_outline(self):
-        """Nothing to delimit: the robot has seen all of it."""
-        db, coords = _dashboard(_Scene(_photo_view()))
+    def test_the_frame_covers_the_grid_and_the_image_s_content(self):
+        """Not the image's full extent: ProcTHOR's square camera pads a
+        non-square house with blank skybox, and framing on that padding shrinks
+        the map for nothing.
+
+        The image still *draws* at its full extent -- only the view is trimmed,
+        so a misfire here crops slightly and can never misplace anything.
+        """
+        # Content in the middle half of the image, blank around it.
+        image = np.full((40, 40, 3), 255, dtype=np.uint8)
+        image[10:30, 10:30] = (10, 120, 200)
+        view = TopDownView(image=image, min_x=0.0, max_x=40.0, min_y=0.0, max_y=40.0)
+
+        db, coords = _dashboard(_Scene(view))
         _figure, ax = _main_axes(db, coords)
-        outline = _layer(ax, 0.5)
-        assert outline is None or np.asarray(outline.get_array())[:, :, 3].max() == 0
+        n_x, n_y = GRID_SHAPE
+        assert ax.get_xlim() == pytest.approx((-0.5, 30.0))
+        assert ax.get_ylim() == pytest.approx((30.0, -0.5))
+        assert _layer(ax, -1).get_extent() == pytest.approx((0.0, 40.0, 40.0, 0.0))
 
-    def test_the_grid_turns_translucent_only_over_an_image(self):
-        """Opaque obstacle fill would hide the very thing being drawn under it."""
-        db, coords = _dashboard(_Scene(_photo_view()))
-        _figure, ax = _main_axes(db, coords)
-        assert isinstance(_layer(ax, 0).get_alpha(), np.ndarray)
-
-        db, coords = _dashboard(None)
-        _figure, ax = _main_axes(db, coords)
-        assert ax.get_images()[0].get_alpha() is None
-
-    def test_the_axes_widen_to_include_the_image(self):
-        """Clamping to the grid would crop off the walls it stops short of."""
+        # An image with no blank border -- railsim's, one pixel per cell --
+        # must not be trimmed at all.
         db, coords = _dashboard(_Scene(_photo_view()))
         _figure, ax = _main_axes(db, coords)
         assert ax.get_xlim() == pytest.approx(
@@ -150,10 +161,9 @@ class TestPhotoUnderlay:
             (PHOTO_EXTENT["max_y"], PHOTO_EXTENT["min_y"])
         )
 
-    def test_without_an_image_the_axes_frame_the_grid(self):
+        # And with no image at all, the grid alone sets the frame.
         db, coords = _dashboard(None)
         _figure, ax = _main_axes(db, coords)
-        n_x, n_y = GRID_SHAPE
         assert ax.get_xlim() == pytest.approx((-0.5, n_x - 0.5))
         assert ax.get_ylim() == pytest.approx((n_y - 0.5, -0.5))
 
@@ -172,66 +182,17 @@ class TestPhotoUnderlay:
         assert ax.get_xlim()[1] >= outside["B"][0]
         assert ax.get_ylim()[0] >= outside["B"][1]
 
-    def test_a_scene_that_cannot_place_its_image_gets_a_plain_grid(self):
-        """The stale-ProcTHOR-cache path: no image beats a misaligned one."""
-        db, coords = _dashboard(_Scene(None))
-        _figure, ax = _main_axes(db, coords)
-        assert len(ax.get_images()) == 1
-
-    def test_an_unpositioned_legacy_scene_is_ignored(self):
-        """``get_top_down_image`` alone says nothing about where the image sits."""
+    @pytest.mark.parametrize("scene", ["declines", "legacy"])
+    def test_a_scene_that_cannot_place_an_image_gets_a_plain_grid(self, scene):
+        """A stale ProcTHOR cache declines; an older provider offers only
+        ``get_top_down_image``, which says nothing about where the image sits.
+        Either way an unplaceable image is worse than none."""
 
         class LegacyScene:
             def get_top_down_image(self, orthographic=True):
                 return np.zeros((8, 8, 3), dtype=np.uint8)
 
-        db, coords = _dashboard(LegacyScene())
+        provider = _Scene(None) if scene == "declines" else LegacyScene()
+        db, coords = _dashboard(provider)
         _figure, ax = _main_axes(db, coords)
         assert len(ax.get_images()) == 1
-
-
-class TestContentFraming:
-    """ProcTHOR's square camera pads a non-square house with blank skybox.
-
-    Framing on that padding shrinks the map for nothing, so the limits follow
-    the image's content instead. This only moves the *view*: the image is still
-    drawn at its true extent, so a misfire crops slightly and never misplaces.
-    """
-
-    def _blank_edged_view(self):
-        # Content occupies the middle half of the image, blank around it.
-        image = np.full((40, 40, 3), 255, dtype=np.uint8)
-        image[10:30, 10:30] = (10, 120, 200)
-        return TopDownView(image=image, min_x=0.0, max_x=40.0,
-                           min_y=0.0, max_y=40.0)
-
-    def test_blank_margin_is_left_out_of_the_frame(self):
-        db, coords = _dashboard(_Scene(self._blank_edged_view()))
-        _figure, ax = _main_axes(db, coords)
-        # Grid is 30x20, image content spans 10..30 -- union of the two.
-        assert ax.get_xlim() == pytest.approx((-0.5, 30.0))
-        assert ax.get_ylim() == pytest.approx((30.0, -0.5))
-
-    def test_the_image_still_draws_at_its_full_extent(self):
-        """Framing is a view choice; it must not move the pixels."""
-        db, coords = _dashboard(_Scene(self._blank_edged_view()))
-        _figure, ax = _main_axes(db, coords)
-        photo = min(ax.get_images(), key=lambda im: im.get_zorder())
-        assert photo.get_extent() == pytest.approx((0.0, 40.0, 40.0, 0.0))
-
-    def test_an_image_with_no_blank_border_frames_unchanged(self):
-        """railsim's is one pixel per cell with no skybox; it must not shrink."""
-        db, coords = _dashboard(_Scene(_photo_view()))
-        _figure, ax = _main_axes(db, coords)
-        assert ax.get_xlim() == pytest.approx(
-            (PHOTO_EXTENT["min_x"], PHOTO_EXTENT["max_x"])
-        )
-
-
-class TestFigureLayout:
-    @pytest.mark.parametrize("scene", [None, "photo"])
-    def test_there_is_no_separate_overhead_panel(self, scene):
-        """Regression guard for the GridSpec collapse to main + sidebar."""
-        db, coords = _dashboard(_Scene(_photo_view()) if scene else None)
-        figure, _ax = _main_axes(db, coords)
-        assert len(figure.axes) == 2

--- a/packages/railroad/tests/test_dashboard_overhead.py
+++ b/packages/railroad/tests/test_dashboard_overhead.py
@@ -168,12 +168,14 @@ class TestPhotoUnderlay:
         assert ax.get_ylim() == pytest.approx((n_y - 0.5, -0.5))
 
     @pytest.mark.parametrize("scene", [None, "photo"])
-    def test_a_path_leaving_the_grid_is_not_cropped(self, scene):
+    def test_what_a_caller_plots_outside_the_grid_is_not_cropped(self, scene):
         """Pinning the limits turns autoscale off, which used to be free.
 
-        Callers may plot coordinates that do not all fall inside the occupancy
-        grid; before the limits were set explicitly those simply expanded the
-        view, and they must still be visible rather than silently clipped.
+        ``plot_trajectories`` explicitly supports caller-supplied
+        ``location_coords``, which need not all fall inside the occupancy grid.
+        Before the limits were set explicitly those simply expanded the view;
+        they must still be visible rather than silently clipped -- the marker
+        and its label as much as the path reaching it.
         """
         db, _coords = _dashboard(_Scene(_photo_view()) if scene else None)
         n_x, n_y = GRID_SHAPE
@@ -181,6 +183,13 @@ class TestPhotoUnderlay:
         _figure, ax = _main_axes(db, outside)
         assert ax.get_xlim()[1] >= outside["B"][0]
         assert ax.get_ylim()[0] >= outside["B"][1]
+
+        # Every black location marker inside the frame, not just the trail.
+        left, right = ax.get_xlim()
+        bottom, top = ax.get_ylim()
+        for collection in ax.collections:
+            for x, y in collection.get_offsets():
+                assert left <= x <= right and top <= y <= bottom
 
     @pytest.mark.parametrize("scene", ["declines", "legacy"])
     def test_a_scene_that_cannot_place_an_image_gets_a_plain_grid(self, scene):

--- a/packages/railroad/tests/test_dashboard_overhead.py
+++ b/packages/railroad/tests/test_dashboard_overhead.py
@@ -23,6 +23,7 @@ from railroad.core import Fluent as F, State
 from railroad.dashboard import PlannerDashboard
 from railroad.environment import ObjectSearchEnvironment
 from railroad.environment.types import TopDownView
+from railroad.navigation.constants import UNOBSERVED_VAL
 
 GRID_SHAPE = (30, 20)
 # Deliberately wider than the grid, as ProcTHOR's is: its grid spans only the
@@ -46,10 +47,13 @@ def _photo_view():
     return TopDownView(image=image, **PHOTO_EXTENT)
 
 
-def _dashboard(scene):
+def _dashboard(scene, *, unobserved: bool = False):
     grid = np.zeros(GRID_SHAPE)
     grid[0, :] = 1.0
     grid[-1, :] = 1.0
+    if unobserved:
+        # Mid-exploration: a band the robot has not looked at yet.
+        grid[:, GRID_SHAPE[1] // 2:] = UNOBSERVED_VAL
 
     move_op = operators.construct_move_operator_blocking(lambda r, a, b: 10.0)
     no_op = operators.construct_no_op_operator(no_op_time=1.0, extra_cost=10.0)
@@ -75,13 +79,19 @@ def _main_axes(db, coords):
     return figure, figure.axes[0]
 
 
+def _layer(ax, zorder):
+    """The image drawn at *zorder*: -1 photo, 0 grid, 0.5 known-region outline."""
+    matches = [im for im in ax.get_images() if im.get_zorder() == zorder]
+    assert len(matches) <= 1, f"{len(matches)} images at zorder {zorder}"
+    return matches[0] if matches else None
+
+
 class TestPhotoUnderlay:
     def test_the_image_is_drawn_below_the_grid(self):
         db, coords = _dashboard(_Scene(_photo_view()))
         _figure, ax = _main_axes(db, coords)
-        images = sorted(ax.get_images(), key=lambda im: im.get_zorder())
-        assert len(images) == 2
-        photo, grid = images
+        photo, grid = _layer(ax, -1), _layer(ax, 0)
+        assert photo is not None and grid is not None
         assert photo.get_zorder() < grid.get_zorder()
         left, right, bottom, top = photo.get_extent()
         assert (left, right, bottom, top) == pytest.approx((
@@ -89,12 +99,40 @@ class TestPhotoUnderlay:
             PHOTO_EXTENT["max_y"], PHOTO_EXTENT["min_y"],
         ))
 
+    def test_the_grid_vanishes_over_an_image_when_the_map_is_known(self):
+        """With the whole map known, the image says everything the grid does."""
+        db, coords = _dashboard(_Scene(_photo_view()))
+        _figure, ax = _main_axes(db, coords)
+        assert np.asarray(_layer(ax, 0).get_alpha()).max() == pytest.approx(0.0)
+
+    def test_how_far_the_robot_has_seen_is_outlined_not_shaded(self):
+        """The one thing an image cannot show is where the robot has not looked.
+
+        It renders ground truth everywhere, so the extent of what has been
+        observed is drawn -- but as an outline, since shading the unobserved
+        region buries the map the image is there to show.
+        """
+        db, coords = _dashboard(_Scene(_photo_view()), unobserved=True)
+        _figure, ax = _main_axes(db, coords)
+        outline = _layer(ax, 0.5)
+        assert outline is not None, "no known-region outline drawn"
+        opacity = np.asarray(outline.get_array())[:, :, 3]
+        assert opacity.max() > 0.5, "outline is invisible"
+        # An outline, not a wash: only a thin border is painted at all.
+        assert (opacity > 0).mean() < 0.2
+
+    def test_a_fully_known_map_gets_no_outline(self):
+        """Nothing to delimit: the robot has seen all of it."""
+        db, coords = _dashboard(_Scene(_photo_view()))
+        _figure, ax = _main_axes(db, coords)
+        outline = _layer(ax, 0.5)
+        assert outline is None or np.asarray(outline.get_array())[:, :, 3].max() == 0
+
     def test_the_grid_turns_translucent_only_over_an_image(self):
         """Opaque obstacle fill would hide the very thing being drawn under it."""
         db, coords = _dashboard(_Scene(_photo_view()))
         _figure, ax = _main_axes(db, coords)
-        grid = max(ax.get_images(), key=lambda im: im.get_zorder())
-        assert isinstance(grid.get_alpha(), np.ndarray)
+        assert isinstance(_layer(ax, 0).get_alpha(), np.ndarray)
 
         db, coords = _dashboard(None)
         _figure, ax = _main_axes(db, coords)

--- a/packages/railroad/tests/test_dashboard_overhead.py
+++ b/packages/railroad/tests/test_dashboard_overhead.py
@@ -1,0 +1,199 @@
+"""Drawing the scene's overhead image underneath the trajectory.
+
+The overhead image used to occupy its own column of the figure, alongside an
+occupancy-grid trajectory panel it could not be registered against. Now that
+scenes report where their image sits, it goes underneath the trajectory in the
+main axes and the extra column is gone.
+
+These tests use a synthetic scene rather than ProcTHOR or railsim, so they say
+nothing about whether a *particular* scene's extent is right -- that belongs to
+the providers' own tests -- only that the dashboard wires it up in the right
+order, with the right limits, and degrades to a plain grid when a scene cannot
+place its image.
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+
+from railroad import operators
+from railroad.core import Fluent as F, State
+from railroad.dashboard import PlannerDashboard
+from railroad.environment import ObjectSearchEnvironment
+from railroad.environment.types import TopDownView
+
+GRID_SHAPE = (30, 20)
+# Deliberately wider than the grid, as ProcTHOR's is: its grid spans only the
+# agent-reachable bbox, while the camera frames the whole house.
+PHOTO_EXTENT = dict(min_x=-6.0, max_x=35.0, min_y=-4.0, max_y=23.0)
+
+
+class _Scene:
+    """A scene that reports an overhead image, or declines to."""
+
+    def __init__(self, view):
+        self._view = view
+
+    def get_top_down_view(self):
+        return self._view
+
+
+def _photo_view():
+    image = np.zeros((48, 64, 3), dtype=np.uint8)
+    image[:, :] = (10, 120, 200)
+    return TopDownView(image=image, **PHOTO_EXTENT)
+
+
+def _dashboard(scene):
+    grid = np.zeros(GRID_SHAPE)
+    grid[0, :] = 1.0
+    grid[-1, :] = 1.0
+
+    move_op = operators.construct_move_operator_blocking(lambda r, a, b: 10.0)
+    no_op = operators.construct_no_op_operator(no_op_time=1.0, extra_cost=10.0)
+    env = ObjectSearchEnvironment(
+        state=State(0.0, {F("at r1 A"), F("free r1")}, []),
+        objects_by_type={"robot": {"r1"}, "location": {"A", "B"}},
+        operators=[move_op, no_op],
+    )
+    env.occupancy_grid = grid  # ty: ignore[unresolved-attribute]
+    if scene is not None:
+        env.scene = scene  # ty: ignore[unresolved-attribute]
+
+    db = PlannerDashboard(F("at r1 B"), env, force_interactive=False, print_on_exit=False)
+    db.known_robots = {"r1"}
+    db._entity_positions = {"r1": [(0.0, "A", None), (10.0, "B", None)]}
+    db._goal_time = 10.0
+    return db, {"A": (4.0, 4.0), "B": (25.0, 15.0)}
+
+
+def _main_axes(db, coords):
+    figure = db._render_static_plot((10, 6), location_coords=coords)
+    assert figure is not None
+    return figure, figure.axes[0]
+
+
+class TestPhotoUnderlay:
+    def test_the_image_is_drawn_below_the_grid(self):
+        db, coords = _dashboard(_Scene(_photo_view()))
+        _figure, ax = _main_axes(db, coords)
+        images = sorted(ax.get_images(), key=lambda im: im.get_zorder())
+        assert len(images) == 2
+        photo, grid = images
+        assert photo.get_zorder() < grid.get_zorder()
+        left, right, bottom, top = photo.get_extent()
+        assert (left, right, bottom, top) == pytest.approx((
+            PHOTO_EXTENT["min_x"], PHOTO_EXTENT["max_x"],
+            PHOTO_EXTENT["max_y"], PHOTO_EXTENT["min_y"],
+        ))
+
+    def test_the_grid_turns_translucent_only_over_an_image(self):
+        """Opaque obstacle fill would hide the very thing being drawn under it."""
+        db, coords = _dashboard(_Scene(_photo_view()))
+        _figure, ax = _main_axes(db, coords)
+        grid = max(ax.get_images(), key=lambda im: im.get_zorder())
+        assert isinstance(grid.get_alpha(), np.ndarray)
+
+        db, coords = _dashboard(None)
+        _figure, ax = _main_axes(db, coords)
+        assert ax.get_images()[0].get_alpha() is None
+
+    def test_the_axes_widen_to_include_the_image(self):
+        """Clamping to the grid would crop off the walls it stops short of."""
+        db, coords = _dashboard(_Scene(_photo_view()))
+        _figure, ax = _main_axes(db, coords)
+        assert ax.get_xlim() == pytest.approx(
+            (PHOTO_EXTENT["min_x"], PHOTO_EXTENT["max_x"])
+        )
+        # Inverted, so the y axis keeps increasing downward.
+        assert ax.get_ylim() == pytest.approx(
+            (PHOTO_EXTENT["max_y"], PHOTO_EXTENT["min_y"])
+        )
+
+    def test_without_an_image_the_axes_frame_the_grid(self):
+        db, coords = _dashboard(None)
+        _figure, ax = _main_axes(db, coords)
+        n_x, n_y = GRID_SHAPE
+        assert ax.get_xlim() == pytest.approx((-0.5, n_x - 0.5))
+        assert ax.get_ylim() == pytest.approx((n_y - 0.5, -0.5))
+
+    @pytest.mark.parametrize("scene", [None, "photo"])
+    def test_a_path_leaving_the_grid_is_not_cropped(self, scene):
+        """Pinning the limits turns autoscale off, which used to be free.
+
+        Callers may plot coordinates that do not all fall inside the occupancy
+        grid; before the limits were set explicitly those simply expanded the
+        view, and they must still be visible rather than silently clipped.
+        """
+        db, _coords = _dashboard(_Scene(_photo_view()) if scene else None)
+        n_x, n_y = GRID_SHAPE
+        outside = {"A": (4.0, 4.0), "B": (n_x + 25.0, n_y + 18.0)}
+        _figure, ax = _main_axes(db, outside)
+        assert ax.get_xlim()[1] >= outside["B"][0]
+        assert ax.get_ylim()[0] >= outside["B"][1]
+
+    def test_a_scene_that_cannot_place_its_image_gets_a_plain_grid(self):
+        """The stale-ProcTHOR-cache path: no image beats a misaligned one."""
+        db, coords = _dashboard(_Scene(None))
+        _figure, ax = _main_axes(db, coords)
+        assert len(ax.get_images()) == 1
+
+    def test_an_unpositioned_legacy_scene_is_ignored(self):
+        """``get_top_down_image`` alone says nothing about where the image sits."""
+
+        class LegacyScene:
+            def get_top_down_image(self, orthographic=True):
+                return np.zeros((8, 8, 3), dtype=np.uint8)
+
+        db, coords = _dashboard(LegacyScene())
+        _figure, ax = _main_axes(db, coords)
+        assert len(ax.get_images()) == 1
+
+
+class TestContentFraming:
+    """ProcTHOR's square camera pads a non-square house with blank skybox.
+
+    Framing on that padding shrinks the map for nothing, so the limits follow
+    the image's content instead. This only moves the *view*: the image is still
+    drawn at its true extent, so a misfire crops slightly and never misplaces.
+    """
+
+    def _blank_edged_view(self):
+        # Content occupies the middle half of the image, blank around it.
+        image = np.full((40, 40, 3), 255, dtype=np.uint8)
+        image[10:30, 10:30] = (10, 120, 200)
+        return TopDownView(image=image, min_x=0.0, max_x=40.0,
+                           min_y=0.0, max_y=40.0)
+
+    def test_blank_margin_is_left_out_of_the_frame(self):
+        db, coords = _dashboard(_Scene(self._blank_edged_view()))
+        _figure, ax = _main_axes(db, coords)
+        # Grid is 30x20, image content spans 10..30 -- union of the two.
+        assert ax.get_xlim() == pytest.approx((-0.5, 30.0))
+        assert ax.get_ylim() == pytest.approx((30.0, -0.5))
+
+    def test_the_image_still_draws_at_its_full_extent(self):
+        """Framing is a view choice; it must not move the pixels."""
+        db, coords = _dashboard(_Scene(self._blank_edged_view()))
+        _figure, ax = _main_axes(db, coords)
+        photo = min(ax.get_images(), key=lambda im: im.get_zorder())
+        assert photo.get_extent() == pytest.approx((0.0, 40.0, 40.0, 0.0))
+
+    def test_an_image_with_no_blank_border_frames_unchanged(self):
+        """railsim's is one pixel per cell with no skybox; it must not shrink."""
+        db, coords = _dashboard(_Scene(_photo_view()))
+        _figure, ax = _main_axes(db, coords)
+        assert ax.get_xlim() == pytest.approx(
+            (PHOTO_EXTENT["min_x"], PHOTO_EXTENT["max_x"])
+        )
+
+
+class TestFigureLayout:
+    @pytest.mark.parametrize("scene", [None, "photo"])
+    def test_there_is_no_separate_overhead_panel(self, scene):
+        """Regression guard for the GridSpec collapse to main + sidebar."""
+        db, coords = _dashboard(_Scene(_photo_view()) if scene else None)
+        figure, _ax = _main_axes(db, coords)
+        assert len(figure.axes) == 2

--- a/packages/railroad/tests/test_known_boundary.py
+++ b/packages/railroad/tests/test_known_boundary.py
@@ -124,7 +124,22 @@ def test_only_what_cannot_be_stood_on_is_shaded():
     grid = _room()
     grid[3:8, 3:8] = 0.0
 
-    shade = np.transpose(make_untraversable_shade_rgba(grid), (1, 0, 2))[:, :, 3]
+    rgba, extent = make_untraversable_shade_rgba(grid)
+    shade = np.transpose(rgba, (1, 0, 2))[:, :, 3]
     free = grid == 0.0
     np.testing.assert_allclose(shade[free], 0.0)
     np.testing.assert_allclose(shade[~free], UNTRAVERSABLE_SHADE)
+    assert extent == (-0.5, grid.shape[0] - 0.5, grid.shape[1] - 0.5, -0.5)
+
+
+def test_the_shade_reaches_an_image_wider_than_the_map():
+    """The grid spans only the reachable bbox, so a scene image runs past it --
+    and everything out there is somewhere the robot cannot be either."""
+    grid = np.zeros((6, 6))
+
+    rgba, extent = make_untraversable_shade_rgba(grid, (-4.5, 9.5, 9.5, -4.5))
+    assert extent[0] <= -4.5 and extent[1] >= 9.5
+    assert extent[3] <= -4.5 and extent[2] >= 9.5
+    # Padded with untraversable, so only the original free cells stay clear.
+    shade = np.transpose(rgba, (1, 0, 2))[:, :, 3]
+    assert (shade == 0.0).sum() == grid.size

--- a/packages/railroad/tests/test_known_boundary.py
+++ b/packages/railroad/tests/test_known_boundary.py
@@ -3,9 +3,6 @@
 Drawn over a scene image, which renders ground truth everywhere including
 where the robot has not looked. The outline says how far it has seen without
 shading over the map.
-
-The property that matters is that the outline is *closed*: a gap reads as
-"the robot knows what is through here", which is the opposite of the truth.
 """
 
 import numpy as np
@@ -19,18 +16,41 @@ from railroad.navigation.plotting import (
 )
 
 
-def _painted(grid: np.ndarray) -> np.ndarray:
-    """Mask of outlined cells, back in grid orientation."""
-    rgba = make_known_boundary_rgba(grid)
-    return np.transpose(rgba, (1, 0, 2))[:, :, 3] > 0
+def _in_grid_orientation(grid: np.ndarray) -> np.ndarray:
+    """The overlay, transposed back so it indexes like the grid."""
+    return np.transpose(make_known_boundary_rgba(grid), (1, 0, 2))
 
 
-def _should_be_outlined(grid: np.ndarray) -> np.ndarray:
-    """Every observed cell touching the unknown, or the edge of the map.
+def _room(n: int = 12) -> np.ndarray:
+    """A walled room, entirely unobserved."""
+    grid = np.full((n, n), UNOBSERVED_VAL)
+    grid[0, :] = grid[-1, :] = grid[:, 0] = grid[:, -1] = 1.0
+    return grid
 
-    Computed the long way round -- an explicit 8-neighbour sweep with
-    off-grid treated as unknown -- so it does not simply restate the
-    implementation.
+
+def _seen_patch() -> np.ndarray:
+    grid = _room()
+    grid[3:8, 3:8] = 0.0
+    return grid
+
+
+def _seen_to_the_map_edge() -> np.ndarray:
+    """Observed space running off three sides of the array."""
+    grid = np.full((12, 12), UNOBSERVED_VAL)
+    grid[:, :5] = 0.0
+    return grid
+
+
+@pytest.mark.parametrize("grid", [_seen_patch(), _seen_to_the_map_edge()])
+def test_the_outline_is_closed(grid):
+    """A gap reads as "the robot knows what is through here" -- the opposite.
+
+    The second case is the one that bit: observed space running to the edge of
+    the array has no unknown cell beyond it, so nothing was drawn along that
+    whole stretch and the outline leaked.
+
+    Checked against an explicit 8-neighbour sweep, with off-grid counted as
+    unknown, so this does not simply restate the implementation.
     """
     unknown = grid == UNOBSERVED_VAL
     n_rows, n_cols = grid.shape
@@ -42,80 +62,39 @@ def _should_be_outlined(grid: np.ndarray) -> np.ndarray:
             for d_row in (-1, 0, 1):
                 for d_col in (-1, 0, 1):
                     r, c = row + d_row, col + d_col
-                    off_grid = not (0 <= r < n_rows and 0 <= c < n_cols)
-                    if off_grid or unknown[r, c]:
+                    if not (0 <= r < n_rows and 0 <= c < n_cols) or unknown[r, c]:
                         expected[row, col] = True
-    return expected
+
+    painted = _in_grid_orientation(grid)[:, :, 3] > 0
+    np.testing.assert_array_equal(painted, expected)
+    # An outline, not a wash: the map it is drawn over stays visible.
+    assert not (painted & unknown).any()
 
 
-def _room(n: int = 12) -> np.ndarray:
-    """A walled room, entirely unobserved."""
-    grid = np.full((n, n), UNOBSERVED_VAL)
-    grid[0, :] = grid[-1, :] = grid[:, 0] = grid[:, -1] = 1.0
-    return grid
+def test_the_outline_says_why_it_ends():
+    """Black where the robot has seen what stops it, colour where it has not.
 
+    Told apart because they mean opposite things: one is a wall, the other is
+    somewhere exploration could still go.
+    """
+    grid = _room()
+    grid[2:6, 2:6] = 0.0
+    grid[2:6, 6] = 1.0  # an observed wall, unknown beyond it
 
-class TestTheOutlineIsClosed:
-    def test_it_covers_every_cell_that_borders_the_unknown(self):
-        grid = _room()
-        grid[3:8, 3:8] = 0.0  # a patch the robot has seen
-        np.testing.assert_array_equal(_painted(grid), _should_be_outlined(grid))
+    rgba = _in_grid_orientation(grid)
+    np.testing.assert_allclose(rgba[3, 6, :3], KNOWN_WALL_COLOR)
+    np.testing.assert_allclose(rgba[3, 2, :3], FRONTIER_COLOR)
 
-    def test_observed_space_running_off_the_map_still_closes(self):
-        """The bug: no unknown cell beyond the array, so nothing was drawn.
-
-        A robot that has seen right up to the edge of its grid left the
-        outline open along that whole stretch.
-        """
-        grid = np.full((12, 12), UNOBSERVED_VAL)
-        grid[:, :5] = 0.0  # observed all the way to three map edges
-        painted = _painted(grid)
-        np.testing.assert_array_equal(painted, _should_be_outlined(grid))
-        assert painted[0, :5].all(), "top edge is open"
-        assert painted[-1, :5].all(), "bottom edge is open"
-        assert painted[:, 0].all(), "left edge is open"
-
-    def test_a_fully_observed_map_needs_no_outline(self):
-        grid = np.zeros((8, 8))
-        assert not _painted(grid).any()
-
-
-class TestTheOutlineSaysWhyItEnds:
-    def test_walls_are_black_and_frontiers_are_grey(self):
-        grid = _room()
-        # Observed free space, walled on one side and open on the other.
-        grid[2:6, 2:6] = 0.0
-        grid[2:6, 6] = 1.0  # an observed wall, unknown beyond it
-
-        rgba = np.transpose(make_known_boundary_rgba(grid), (1, 0, 2))
-        np.testing.assert_allclose(rgba[3, 6, :3], KNOWN_WALL_COLOR)
-        np.testing.assert_allclose(rgba[3, 2, :3], FRONTIER_COLOR)
-
-    def test_it_stays_an_outline_rather_than_a_wash(self):
-        """The whole reason for drawing this instead of shading the unknown.
-
-        Stated against the unknown region it delimits rather than as a fraction
-        of the grid, which would just measure how much perimeter the fixture
-        happens to have.
-        """
-        grid = _room(40)
-        grid[5:35, 5:20] = 0.0
-        painted = _painted(grid)
-        unknown = grid == UNOBSERVED_VAL
-        assert not (painted & unknown).any(), "painting over the unknown region"
-        assert painted.sum() < 0.35 * unknown.sum()
-
-    def test_the_frontier_grey_reads_against_a_dark_room(self):
-        """Mid-grey, not near-black: it sits on a photo of unknown brightness."""
-        assert 0.5 < FRONTIER_COLOR[0] < 0.85
-        assert FRONTIER_COLOR > KNOWN_WALL_COLOR
+    # Nothing to delimit once everything has been seen.
+    assert not _in_grid_orientation(np.zeros((8, 8)))[:, :, 3].any()
 
 
 def test_the_outline_matches_the_planner_s_own_frontier_rule():
-    """Grey cells must be exactly what ``extract_frontiers`` calls a frontier.
+    """Frontier cells must be exactly what ``extract_frontiers`` calls one.
 
     The rule is repeated in plotting rather than imported, because plotting
-    sits below the exploration package -- so pin the two together.
+    sits below the exploration package -- so pin the two together, or they
+    drift and the plot quietly disagrees with the planner.
     """
     extract = pytest.importorskip(
         "railroad.experimental.unknown_search.frontiers"
@@ -125,11 +104,13 @@ def test_the_outline_matches_the_planner_s_own_frontier_rule():
     grid[4:16, 4:12] = 0.0
     grid[4:16, 12] = 1.0
 
-    rgba = np.transpose(make_known_boundary_rgba(grid), (1, 0, 2))
-    grey = np.all(np.isclose(rgba[:, :, :3], FRONTIER_COLOR), axis=2) & (rgba[:, :, 3] > 0)
+    rgba = _in_grid_orientation(grid)
+    painted_as_frontier = (
+        np.all(np.isclose(rgba[:, :, :3], FRONTIER_COLOR), axis=2) & (rgba[:, :, 3] > 0)
+    )
 
     from_planner = np.zeros(grid.shape, dtype=bool)
     for frontier in extract(grid):
         from_planner[frontier.cells[0], frontier.cells[1]] = True
 
-    np.testing.assert_array_equal(grey, from_planner)
+    np.testing.assert_array_equal(painted_as_frontier, from_planner)

--- a/packages/railroad/tests/test_known_boundary.py
+++ b/packages/railroad/tests/test_known_boundary.py
@@ -12,7 +12,9 @@ from railroad.navigation.constants import UNOBSERVED_VAL
 from railroad.navigation.plotting import (
     FRONTIER_COLOR,
     KNOWN_WALL_COLOR,
+    UNTRAVERSABLE_SHADE,
     make_known_boundary_rgba,
+    make_untraversable_shade_rgba,
 )
 
 
@@ -114,3 +116,15 @@ def test_the_outline_matches_the_planner_s_own_frontier_rule():
         from_planner[frontier.cells[0], frontier.cells[1]] = True
 
     np.testing.assert_array_equal(painted_as_frontier, from_planner)
+
+
+def test_only_what_cannot_be_stood_on_is_shaded():
+    """An image shows the room, not the map; furniture reads as floor from
+    above unless the space the robot can move through is picked out."""
+    grid = _room()
+    grid[3:8, 3:8] = 0.0
+
+    shade = np.transpose(make_untraversable_shade_rgba(grid), (1, 0, 2))[:, :, 3]
+    free = grid == 0.0
+    np.testing.assert_allclose(shade[free], 0.0)
+    np.testing.assert_allclose(shade[~free], UNTRAVERSABLE_SHADE)

--- a/packages/railroad/tests/test_known_boundary.py
+++ b/packages/railroad/tests/test_known_boundary.py
@@ -1,0 +1,135 @@
+"""Outlining the region a robot has observed.
+
+Drawn over a scene image, which renders ground truth everywhere including
+where the robot has not looked. The outline says how far it has seen without
+shading over the map.
+
+The property that matters is that the outline is *closed*: a gap reads as
+"the robot knows what is through here", which is the opposite of the truth.
+"""
+
+import numpy as np
+import pytest
+
+from railroad.navigation.constants import UNOBSERVED_VAL
+from railroad.navigation.plotting import (
+    FRONTIER_COLOR,
+    KNOWN_WALL_COLOR,
+    make_known_boundary_rgba,
+)
+
+
+def _painted(grid: np.ndarray) -> np.ndarray:
+    """Mask of outlined cells, back in grid orientation."""
+    rgba = make_known_boundary_rgba(grid)
+    return np.transpose(rgba, (1, 0, 2))[:, :, 3] > 0
+
+
+def _should_be_outlined(grid: np.ndarray) -> np.ndarray:
+    """Every observed cell touching the unknown, or the edge of the map.
+
+    Computed the long way round -- an explicit 8-neighbour sweep with
+    off-grid treated as unknown -- so it does not simply restate the
+    implementation.
+    """
+    unknown = grid == UNOBSERVED_VAL
+    n_rows, n_cols = grid.shape
+    expected = np.zeros_like(unknown)
+    for row in range(n_rows):
+        for col in range(n_cols):
+            if unknown[row, col]:
+                continue
+            for d_row in (-1, 0, 1):
+                for d_col in (-1, 0, 1):
+                    r, c = row + d_row, col + d_col
+                    off_grid = not (0 <= r < n_rows and 0 <= c < n_cols)
+                    if off_grid or unknown[r, c]:
+                        expected[row, col] = True
+    return expected
+
+
+def _room(n: int = 12) -> np.ndarray:
+    """A walled room, entirely unobserved."""
+    grid = np.full((n, n), UNOBSERVED_VAL)
+    grid[0, :] = grid[-1, :] = grid[:, 0] = grid[:, -1] = 1.0
+    return grid
+
+
+class TestTheOutlineIsClosed:
+    def test_it_covers_every_cell_that_borders_the_unknown(self):
+        grid = _room()
+        grid[3:8, 3:8] = 0.0  # a patch the robot has seen
+        np.testing.assert_array_equal(_painted(grid), _should_be_outlined(grid))
+
+    def test_observed_space_running_off_the_map_still_closes(self):
+        """The bug: no unknown cell beyond the array, so nothing was drawn.
+
+        A robot that has seen right up to the edge of its grid left the
+        outline open along that whole stretch.
+        """
+        grid = np.full((12, 12), UNOBSERVED_VAL)
+        grid[:, :5] = 0.0  # observed all the way to three map edges
+        painted = _painted(grid)
+        np.testing.assert_array_equal(painted, _should_be_outlined(grid))
+        assert painted[0, :5].all(), "top edge is open"
+        assert painted[-1, :5].all(), "bottom edge is open"
+        assert painted[:, 0].all(), "left edge is open"
+
+    def test_a_fully_observed_map_needs_no_outline(self):
+        grid = np.zeros((8, 8))
+        assert not _painted(grid).any()
+
+
+class TestTheOutlineSaysWhyItEnds:
+    def test_walls_are_black_and_frontiers_are_grey(self):
+        grid = _room()
+        # Observed free space, walled on one side and open on the other.
+        grid[2:6, 2:6] = 0.0
+        grid[2:6, 6] = 1.0  # an observed wall, unknown beyond it
+
+        rgba = np.transpose(make_known_boundary_rgba(grid), (1, 0, 2))
+        np.testing.assert_allclose(rgba[3, 6, :3], KNOWN_WALL_COLOR)
+        np.testing.assert_allclose(rgba[3, 2, :3], FRONTIER_COLOR)
+
+    def test_it_stays_an_outline_rather_than_a_wash(self):
+        """The whole reason for drawing this instead of shading the unknown.
+
+        Stated against the unknown region it delimits rather than as a fraction
+        of the grid, which would just measure how much perimeter the fixture
+        happens to have.
+        """
+        grid = _room(40)
+        grid[5:35, 5:20] = 0.0
+        painted = _painted(grid)
+        unknown = grid == UNOBSERVED_VAL
+        assert not (painted & unknown).any(), "painting over the unknown region"
+        assert painted.sum() < 0.35 * unknown.sum()
+
+    def test_the_frontier_grey_reads_against_a_dark_room(self):
+        """Mid-grey, not near-black: it sits on a photo of unknown brightness."""
+        assert 0.5 < FRONTIER_COLOR[0] < 0.85
+        assert FRONTIER_COLOR > KNOWN_WALL_COLOR
+
+
+def test_the_outline_matches_the_planner_s_own_frontier_rule():
+    """Grey cells must be exactly what ``extract_frontiers`` calls a frontier.
+
+    The rule is repeated in plotting rather than imported, because plotting
+    sits below the exploration package -- so pin the two together.
+    """
+    extract = pytest.importorskip(
+        "railroad.experimental.unknown_search.frontiers"
+    ).extract_frontiers
+
+    grid = _room(20)
+    grid[4:16, 4:12] = 0.0
+    grid[4:16, 12] = 1.0
+
+    rgba = np.transpose(make_known_boundary_rgba(grid), (1, 0, 2))
+    grey = np.all(np.isclose(rgba[:, :, :3], FRONTIER_COLOR), axis=2) & (rgba[:, :, 3] > 0)
+
+    from_planner = np.zeros(grid.shape, dtype=bool)
+    for frontier in extract(grid):
+        from_planner[frontier.cells[0], frontier.cells[1]] = True
+
+    np.testing.assert_array_equal(grey, from_planner)

--- a/packages/railroad/tests/test_video_compositing.py
+++ b/packages/railroad/tests/test_video_compositing.py
@@ -238,12 +238,11 @@ class TestSaveVideoEndToEnd:
 class TestSceneImageSurvivesCompositing:
     """The overhead image is static chrome, not a per-frame artist.
 
-    ``save_video`` caches a "chrome" raster and replays only the moving
-    artists over it. The scene image is deliberately left out of the layered
-    artist sets so the plain ``canvas.draw()`` in ``_draw_chrome`` bakes it
-    into that cache -- it then costs nothing per frame. If it were wired in as
-    an animated artist instead, it would drop out of the restored region and
-    the frames would go white behind the map.
+    ``save_video`` caches a "chrome" raster and replays only moving artists
+    over it. The image is deliberately left out of the layered artist sets so
+    the plain ``canvas.draw()`` bakes it into that cache. Wire it in as an
+    animated artist instead and it drops out of the restored region, leaving
+    the frames white behind the map.
     """
 
     PHOTO_COLOR = (200, 40, 160)
@@ -257,24 +256,21 @@ class TestSceneImageSurvivesCompositing:
         from railroad.environment import ObjectSearchEnvironment
         from railroad.environment.types import TopDownView
 
-        grid = np.zeros((20, 20))
         image = np.zeros((32, 32, 3), dtype=np.uint8)
         image[:, :] = self.PHOTO_COLOR
 
         class Scene:
             def get_top_down_view(self):
                 # Overhangs the grid on every side, as ProcTHOR's does.
-                return TopDownView(
-                    image=image, min_x=-20.0, max_x=39.0, min_y=-20.0, max_y=39.0,
-                )
+                return TopDownView(image=image, min_x=-20.0, max_x=39.0,
+                                   min_y=-20.0, max_y=39.0)
 
-        move_op = operators.construct_move_operator_blocking(lambda r, a, b: 10.0)
         env = ObjectSearchEnvironment(
             state=State(0.0, {F("at r1 A"), F("free r1")}, []),
             objects_by_type={"robot": {"r1"}, "location": {"A", "B"}},
-            operators=[move_op],
+            operators=[operators.construct_move_operator_blocking(lambda r, a, b: 10.0)],
         )
-        env.occupancy_grid = grid  # ty: ignore[unresolved-attribute]
+        env.occupancy_grid = np.zeros((20, 20))  # ty: ignore[unresolved-attribute]
         env.scene = Scene()  # ty: ignore[unresolved-attribute]
 
         db = PlannerDashboard(
@@ -291,14 +287,13 @@ class TestSceneImageSurvivesCompositing:
     ):
         import subprocess
 
+        import matplotlib.image as mpimg
+
         out = tmp_path / "trajectory.mp4"
         dashboard.save_video(
-            str(out),
-            location_coords={"A": (2.0, 2.0), "B": (17.0, 17.0)},
+            str(out), location_coords={"A": (2.0, 2.0), "B": (17.0, 17.0)},
             fps=5, duration=1.0, figsize=(8.0, 6.0), dpi=100,
         )
-        assert out.is_file()
-
         frames_dir = tmp_path / "frames"
         frames_dir.mkdir()
         subprocess.run(
@@ -309,16 +304,13 @@ class TestSceneImageSurvivesCompositing:
         frames = sorted(frames_dir.glob("frame_*.png"))
         assert len(frames) >= 3
 
-        import matplotlib.image as mpimg
-
         def photo_pixels(path):
             # The image overhangs the grid, so its colour is the only thing
             # that can be in the corner of the axes.
             rgb = (mpimg.imread(str(path))[:, :, :3] * 255).astype(int)
-            target = np.array(self.PHOTO_COLOR)
-            return (np.abs(rgb - target).sum(axis=2) < 60).sum()
+            return (np.abs(rgb - np.array(self.PHOTO_COLOR)).sum(axis=2) < 60).sum()
 
-        counts = [photo_pixels(path) for path in (frames[1], frames[-1])]
+        counts = [photo_pixels(p) for p in (frames[1], frames[-1])]
         assert counts[0] > 500, "scene image missing from the composited frames"
         # Static chrome: the same pixels every frame, modulo h264 noise.
         assert abs(counts[0] - counts[1]) < 0.05 * counts[0]

--- a/packages/railroad/tests/test_video_compositing.py
+++ b/packages/railroad/tests/test_video_compositing.py
@@ -10,6 +10,8 @@ are pinned here instead of being discovered from a corrupted animation.
 import numpy as np
 import pytest
 
+from railroad.navigation.plotting import UNTRAVERSABLE_SHADE
+
 matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use("Agg")
 
@@ -307,11 +309,19 @@ class TestSceneImageSurvivesCompositing:
 
         def photo_pixels(path):
             # The image overhangs the grid, so its colour is the only thing
-            # that can be in the corner of the axes.
+            # that can be in the corner of the axes -- darkened there by the
+            # untraversable shade, hence the generous tolerance.
             rgb = (mpimg.imread(str(path))[:, :, :3] * 255).astype(int)
-            return (np.abs(rgb - np.array(self.PHOTO_COLOR)).sum(axis=2) < 60).sum()
+            shaded = np.array(self.PHOTO_COLOR) * (1 - UNTRAVERSABLE_SHADE)
+            return min(
+                (np.abs(rgb - np.array(self.PHOTO_COLOR)).sum(axis=2) < 60).sum()
+                + (np.abs(rgb - shaded).sum(axis=2) < 60).sum(),
+                rgb.shape[0] * rgb.shape[1],
+            )
 
-        counts = [photo_pixels(p) for p in (frames[1], frames[-1])]
-        assert counts[0] > 500, "scene image missing from the composited frames"
-        # Static chrome: the same pixels every frame, modulo h264 noise.
-        assert abs(counts[0] - counts[1]) < 0.05 * counts[0]
+        # Present early and still present late: were it wired in as an
+        # animated artist it would drop out of the restored region and the
+        # later frames would go blank behind the map. Counted rather than
+        # compared exactly, since the trail grows over the image as it goes.
+        for frame in (frames[1], frames[-1]):
+            assert photo_pixels(frame) > 500, f"scene image missing from {frame.name}"

--- a/packages/railroad/tests/test_video_compositing.py
+++ b/packages/railroad/tests/test_video_compositing.py
@@ -235,6 +235,7 @@ class TestSaveVideoEndToEnd:
         assert int(frames) == 6
 
 
+@pytest.mark.skipif(not _have_ffmpeg(), reason="ffmpeg not installed")
 class TestSceneImageSurvivesCompositing:
     """The overhead image is static chrome, not a per-frame artist.
 

--- a/packages/railroad/tests/test_video_compositing.py
+++ b/packages/railroad/tests/test_video_compositing.py
@@ -233,3 +233,92 @@ class TestSaveVideoEndToEnd:
         assert (int(width), int(height)) == (200, 150)
         # fps * duration, plus the leading poster frame
         assert int(frames) == 6
+
+
+class TestSceneImageSurvivesCompositing:
+    """The overhead image is static chrome, not a per-frame artist.
+
+    ``save_video`` caches a "chrome" raster and replays only the moving
+    artists over it. The scene image is deliberately left out of the layered
+    artist sets so the plain ``canvas.draw()`` in ``_draw_chrome`` bakes it
+    into that cache -- it then costs nothing per frame. If it were wired in as
+    an animated artist instead, it would drop out of the restored region and
+    the frames would go white behind the map.
+    """
+
+    PHOTO_COLOR = (200, 40, 160)
+
+    @pytest.fixture
+    def dashboard(self):
+        from railroad import operators
+        from railroad._bindings import State
+        from railroad.core import Fluent as F
+        from railroad.dashboard import PlannerDashboard
+        from railroad.environment import ObjectSearchEnvironment
+        from railroad.environment.types import TopDownView
+
+        grid = np.zeros((20, 20))
+        image = np.zeros((32, 32, 3), dtype=np.uint8)
+        image[:, :] = self.PHOTO_COLOR
+
+        class Scene:
+            def get_top_down_view(self):
+                # Overhangs the grid on every side, as ProcTHOR's does.
+                return TopDownView(
+                    image=image, min_x=-20.0, max_x=39.0, min_y=-20.0, max_y=39.0,
+                )
+
+        move_op = operators.construct_move_operator_blocking(lambda r, a, b: 10.0)
+        env = ObjectSearchEnvironment(
+            state=State(0.0, {F("at r1 A"), F("free r1")}, []),
+            objects_by_type={"robot": {"r1"}, "location": {"A", "B"}},
+            operators=[move_op],
+        )
+        env.occupancy_grid = grid  # ty: ignore[unresolved-attribute]
+        env.scene = Scene()  # ty: ignore[unresolved-attribute]
+
+        db = PlannerDashboard(
+            F("at r1 B"), env, force_interactive=False, print_on_exit=False,
+        )
+        db.known_robots = {"r1"}
+        db._entity_positions = {"r1": [(0.0, "A", None), (10.0, "B", None)]}
+        db._goal_time = 10.0
+        db.actions_taken = [("move r1 A B", 0.0)]
+        return db
+
+    def test_the_image_is_present_and_unchanged_across_frames(
+        self, dashboard, tmp_path,
+    ):
+        import subprocess
+
+        out = tmp_path / "trajectory.mp4"
+        dashboard.save_video(
+            str(out),
+            location_coords={"A": (2.0, 2.0), "B": (17.0, 17.0)},
+            fps=5, duration=1.0, figsize=(8.0, 6.0), dpi=100,
+        )
+        assert out.is_file()
+
+        frames_dir = tmp_path / "frames"
+        frames_dir.mkdir()
+        subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", str(out),
+             str(frames_dir / "frame_%03d.png")],
+            check=True, capture_output=True,
+        )
+        frames = sorted(frames_dir.glob("frame_*.png"))
+        assert len(frames) >= 3
+
+        import matplotlib.image as mpimg
+
+        def photo_pixels(path):
+            # The image overhangs the grid, so its colour is the only thing
+            # that can be in the corner of the axes.
+            rgb = (mpimg.imread(str(path))[:, :, :3] * 255).astype(int)
+            target = np.array(self.PHOTO_COLOR)
+            return (np.abs(rgb - target).sum(axis=2) < 60).sum()
+
+        counts = [photo_pixels(path) for path in (frames[1], frames[-1])]
+        assert counts[0] > 500, "scene image missing from the composited frames"
+        # Static chrome: the same pixels every frame, modulo h264 noise.
+        assert abs(counts[0] - counts[1]) < 0.05 * counts[0]


### PR DESCRIPTION
ProcTHOR figures showed the top-down photo in its own panel beside an occupancy-grid trajectory plot. The two were never combined because nothing downstream knew where the photo *was* in world space: `_get_top_down_image_from_controller` computed the map-view camera pose and `orthographicSize`, rendered, and threw those numbers away, and the pickle cache kept only pixels. Every normal run is a cache hit with no controller, so by plot time there was nothing left to ask.

Now the trajectory is drawn on the image and the separate panel is gone.

## Why the framing is ours, not AI2-THOR's

Recording what THOR hands back is not enough. It frames its map view on `sceneBounds` — the union of every enabled `Renderer`, which sweeps in geometry not visible from above (ceilings, roof overhang) by a scene-dependent amount. Deriving world coordinates from it is an open upstream bug ([allenai/ai2thor#1181](https://github.com/allenai/ai2thor/issues/1181)), and it cannot be reconstructed from the scene JSON at all: seed 4001 renders a 3.589 m house into a ~4.42 m frame, while seed 8612 fills its frame.

So `top_down_footprint()` derives the footprint from the room floor polygons — exact, in the JSON, with the walls on their boundary — squares it up, adds a margin, and the camera is *told* to frame precisely that. `sceneBounds` survives only for camera **height**, where it cannot affect an orthographic projection. The rotation is pinned to `(90, 0, 0)` with a warning if THOR disagrees: a yaw would skew the footprint into something no rectangular extent can express, silently.

Because the footprint is recomputable, the cached `image_ortho_extent_m` is checked against it on load. A missing or disagreeing extent yields no image and warns once per scene rather than misplacing pixels, so headless runs keep working on stale caches.

**Caches must be regenerated** (`resources/` is gitignored, so this is local-only, and it needs a display). Images already on disk were framed on `sceneBounds` and are rejected by the consistency check, degrading to the grid-only plot with a one-line warning.

## Verification

Across all 14 locally cached scenes the recorded extent matches the computed footprint exactly, and reachable positions — standable floor by construction — land inside the rendered house 100% of the time on 13 of 14. Deliberately transposed, flipped or shifted placements score 43–93%, so the check has real separation rather than being tuned to pass.

The exception is seed 1089 at 78.4%, which is a limit of the *metric*, not a misalignment: a lit pale floor blows out to pure white and joins the skybox through a wall that is also white from above. Confirmed by overlaying its reachable positions, which tile its floors exactly. It is documented and excluded from the test seeds.

## Plot changes

- **Trails are outlined in white**, so they read against a busy image — every trail colour appears somewhere in a real room. One layer beneath the whole trail rather than a per-marker stroke, since markers overlap and a stroke would scallop the line. Video frames stay incremental: the colour pass starts `_TRAIL_REPAINT_OVERLAP` points before the halo pass to paint back the spill, which keeps 121 frames at 1.8 s against 4.7 s for a full repaint. Path crossings are deliberately left un-repainted — that is what makes the later path read as passing over the earlier one.
- **The occupancy grid gets out of the way** over an image (`PHOTO_UNDERLAY_ALPHA = 0.0`), still drawn so the layering stays exercised.
- **What the image cannot show is outlined instead of shaded.** `make_known_boundary_rgba` outlines the observed region: black where an observed obstacle stops it, magenta where free space runs into the unknown. Off-grid counts as unknown, or the outline is simply absent wherever the observed region reaches the edge of its grid — 16 cells across two stretches on the frontier-search example — and a gap reads as "the robot knows what is through here". Magenta rather than grey because grey vanished against railsim's own grey walls (0.12 apart in RGB); magenta is 0.58 from the nearest colour railsim or ProcTHOR uses.
- **Framing follows the image's content**, since a square camera pads a non-square house with up to a third of a frame of skybox.

## Also here

- **A latent railsim transpose bug.** `RailsimScene.get_top_down_image` is indexed `[x, y]` but the plot draws `grid.T`, so its overhead panel was mirrored — invisible in its own axes, obvious underneath a trajectory.
- **Independent ProcTHOR fixes**, kept as separate commits: the scene lock retried on filesystems that can *never* grant it (`ENOLCK`/`EOPNOTSUPP` on NFS/CIFS) and burned the full 1800 s timeout; the cache was pickled straight to its destination, so an interrupt poisoned it permanently; `mkstemp` then left it 0600, which on a shared `PROCTHOR_RESOURCES_DIR` makes every other user regenerate it on every run; and the generating `Controller` was never stopped, so N benchmark workers accumulated N live Unity processes — exactly what the lock exists to prevent.

## Testing

700 pass, `ty` clean. New tests were falsification-checked: reverting each fix makes them fail.
