### PR TITLE
Render no larger than the screen, when the screen cannot be grown

### DIFF
--- a/packages/railroad/src/railroad/environment/procthor/_display.py
+++ b/packages/railroad/src/railroad/environment/procthor/_display.py
@@ -1,10 +1,14 @@
-"""Making a headless X screen big enough for AI2-THOR to render into.
+"""Fitting the render to the X screen AI2-THOR will draw it on.
 
 AI2-THOR's Linux64 platform refuses a render larger than the X screen, and an
 X server with no outputs connected defaults to 1024x768 whatever the GPU can
-do -- so asking for a 2048 top-down image fails before Unity starts. The screen
-can simply be grown, since ``xrandr`` reports a maximum in the tens of
-thousands; it just needs asking.
+do -- so asking for a 2048 top-down image fails before Unity starts.
+
+An Xorg screen can simply be grown, since ``xrandr`` reports a maximum in the
+tens of thousands; it just needs asking. An Xvfb one cannot: its framebuffer is
+sized when the server starts and RandR offers that one size as both minimum and
+maximum, which is what Colab's 1024x768 default leaves you with. So grow what
+can be grown, then ask what is actually there and render no larger.
 """
 
 from __future__ import annotations
@@ -84,3 +88,74 @@ def screen_at_least(width: int, height: int) -> Iterator[bool]:
     finally:
         if grown is not None:
             _xrandr(grown[0], "--fb", f"{grown[1][0]}x{grown[1][1]}")
+
+
+def _usable_screens() -> list[tuple[int, int]]:
+    """The size of every screen AI2-THOR would accept, as it measures them.
+
+    Mirrors ``ai2thor.platform.Linux64._validate_screen``: a screen counts only
+    if it speaks GLX at 24-bit depth, so a screen this reports is one AI2-THOR
+    will consider. Empty when there is no X at all, or no Xlib to ask with.
+    """
+    try:
+        import Xlib.display
+        import Xlib.error
+    except ImportError:
+        return []
+
+    # A server that will not answer is a screen we cannot count, never a reason
+    # to fail: AI2-THOR is about to make the same connection itself, and its
+    # message about it is the better one. ConnectionClosedError is listed
+    # because Xlib does not derive it from XError.
+    unanswered = (
+        Xlib.error.DisplayError,
+        Xlib.error.XError,
+        Xlib.error.ConnectionClosedError,
+        OSError,
+    )
+
+    sizes = []
+    for display in _candidate_displays():
+        try:
+            connection = Xlib.display.Display(display)
+        except unanswered:
+            continue
+        try:
+            for index in range(connection.screen_count()):
+                # AI2-THOR connects per screen rather than indexing one
+                # connection, since ``list_extensions`` is per display.
+                screen_connection = Xlib.display.Display(f"{display}.{index}")
+                try:
+                    screen = screen_connection.screen()
+                    if (
+                        "GLX" in screen_connection.list_extensions()
+                        and screen["root_depth"] == 24
+                    ):
+                        sizes.append(
+                            (screen["width_in_pixels"], screen["height_in_pixels"])
+                        )
+                finally:
+                    screen_connection.close()
+        except unanswered:
+            continue
+        finally:
+            connection.close()
+    return sizes
+
+
+def render_px_at_most(preferred: int) -> int:
+    """The largest square render the X screens will take, capped at *preferred*.
+
+    Call inside :func:`screen_at_least`, so a screen that could be grown has
+    been. What is left is a screen that cannot: rendering smaller keeps the
+    scene generating -- softer than intended, but generated -- where AI2-THOR
+    would otherwise refuse to start.
+
+    Returns *preferred* untouched when nothing can be measured (no X, no Xlib,
+    macOS), leaving AI2-THOR to fail with its own clear message rather than
+    this quietly shrinking a render for a reason it invented.
+    """
+    fits = [min(width, height) for width, height in _usable_screens()]
+    # max, not min: AI2-THOR takes the first screen large enough, so it is the
+    # roomiest one that has to fit, not every one of them.
+    return min(preferred, max(fits)) if fits else preferred

--- a/packages/railroad/src/railroad/environment/procthor/thor_interface.py
+++ b/packages/railroad/src/railroad/environment/procthor/thor_interface.py
@@ -49,7 +49,9 @@ controller is stopped as soon as the cache is written.
 
 AI2-THOR's Linux64 platform refuses a render larger than the X display, and a
 headless screen defaults to 1024x768; ``_display.screen_at_least`` grows it for
-the duration. Lower this if that is not possible.
+the duration, and where it cannot be grown -- Colab's Xvfb, whose framebuffer
+is fixed when the server starts -- ``_display.render_px_at_most`` clamps the
+render to what the screen does offer, so a scene still generates.
 """
 
 JPEG_QUALITY = 75
@@ -140,11 +142,12 @@ class ThorInterface:
                     from ._display import screen_at_least
 
                     with screen_at_least(TOP_DOWN_RENDER_PX, TOP_DOWN_RENDER_PX):
+                        render_px = self._render_px()
                         self.controller = Controller(
                             scene=self.scene,
                             gridSize=self.grid_resolution,
-                            width=TOP_DOWN_RENDER_PX,
-                            height=TOP_DOWN_RENDER_PX,
+                            width=render_px,
+                            height=render_px,
                         )
                         self.cached_data = self._save_and_get_cache()
                         # Inside the lock: otherwise every worker that generates
@@ -164,6 +167,31 @@ class ThorInterface:
         self.scene_graph = self._get_scene_graph()
         self.robot_pose = self._get_robot_pose()
         self.known_cost = self._get_known_costs()
+
+    def _render_px(self) -> int:
+        """The square render size to ask the controller for.
+
+        Call from inside :func:`_display.screen_at_least`, so a screen that
+        could be grown already has been; this is what to do about one that
+        could not. AI2-THOR would refuse to launch at all, which costs the
+        scene; rendering smaller costs sharpness in the cached top-down images
+        and nothing else, so it warns and carries on.
+        """
+        from ._display import render_px_at_most
+
+        render_px = render_px_at_most(TOP_DOWN_RENDER_PX)
+        if render_px < TOP_DOWN_RENDER_PX:
+            warnings.warn(
+                f"The X screen fits a {render_px}x{render_px} render, not "
+                f"{TOP_DOWN_RENDER_PX}x{TOP_DOWN_RENDER_PX}, and could not be "
+                f"grown; caching scene {self.seed}'s top-down images at the "
+                "smaller size. Start a larger server (Xvfb :2 -screen 0 "
+                "2048x2048x24 -ac +extension GLX +render) to keep the full "
+                "resolution, or set PROCTHOR_TOP_DOWN_PX to accept this one.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        return render_px
 
     def _preprocess_containers(self) -> None:
         """Filter containers and their children."""

--- a/packages/railroad/tests/environment/procthor/test_display.py
+++ b/packages/railroad/tests/environment/procthor/test_display.py
@@ -1,10 +1,11 @@
-"""Growing a headless X screen so AI2-THOR will render into it."""
+"""Fitting the render to the X screen AI2-THOR will draw it on."""
 
 import subprocess
+import warnings
 
 import pytest
 
-from railroad.environment.procthor import _display
+from railroad.environment.procthor import _display, thor_interface
 
 SCREEN = "Screen 0: minimum 8 x 8, current 1024 x 768, maximum 32767 x 32767\n"
 
@@ -48,3 +49,25 @@ def test_an_unset_display_is_still_found(monkeypatch):
         assert grew
 
     assert ["xrandr", "-d", ":0", "--fb", "2048x2048"] in calls
+
+
+@pytest.mark.parametrize("screens, render_px", [
+    # Colab's Xvfb, fixed at 1024x768: the roomiest square that fits, squarely,
+    # and loudly -- a stretched render would misplace every overlay on it.
+    ([(800, 600), (1024, 768)], 768),
+    ([(4096, 4096)], 2048),  # room to spare: full size, and nothing to say
+    ([], 2048),  # nothing measurable: AI2-THOR's own message is the better one
+])
+def test_the_render_shrinks_only_to_a_screen_that_cannot_take_it(
+    screens, render_px, monkeypatch
+):
+    monkeypatch.setattr(_display, "_usable_screens", lambda: screens)
+    monkeypatch.setattr(thor_interface, "TOP_DOWN_RENDER_PX", 2048)
+    thor = object.__new__(thor_interface.ThorInterface)  # __init__ loads a scene
+    thor.seed = 7
+
+    with warnings.catch_warnings(record=True) as warned:
+        warnings.simplefilter("always")
+        assert thor._render_px() == render_px
+
+    assert bool(warned) is (render_px < 2048)


### PR DESCRIPTION
Generating a ProcTHOR scene on Colab dies before Unity starts: the 2048 top-down render needs an X screen at least that big, and `ai2thor_colab` starts Xvfb at 1024x768 — a framebuffer sized when the server starts, which `xrandr --fb` cannot grow.

`screen_at_least()` still grows an Xorg screen that will grow. `render_px_at_most()` then measures what is actually there — Xlib, using AI2-THOR's own GLX / 24-bit / dimension checks — and caps the render to the largest square that fits, warning once with the two ways out: a larger server, or `PROCTHOR_TOP_DOWN_PX`. With nothing measurable (no X, no Xlib, macOS) the render is left alone and AI2-THOR fails with its own message.

Shrinking costs sharpness in the cached images and nothing else: the footprint extent comes from the scene JSON, not the pixels.

Three test cases on the clamp — shrink and warn, fits and silent, unmeasurable and untouched. Procthor suite (73) and `-m 'not slow'` (690) pass; `ty` and `ruff` clean.