### PR TITLE
Ring a pulse while a robot searches, and let --video-time size the video

### DIFF
--- a/packages/railroad/src/railroad/cli.py
+++ b/packages/railroad/src/railroad/cli.py
@@ -578,6 +578,26 @@ def pddl_check(collection: str, n_instances: int, ground: bool,
                f"{n_instances} instance(s) each)")
 
 
+def _check_video_time(
+    ctx: click.Context, param: click.Parameter, value: str | None,
+) -> str | None:
+    """Reject a malformed ``--video-time`` before the example runs.
+
+    The spec cannot be turned into a duration until the plan has a cost, and
+    by then the run it would be thrown away with is already paid for.
+    """
+    del ctx, param
+    if value is None:
+        return None
+    from railroad.dashboard.plotting import parse_video_time
+
+    try:
+        parse_video_time(value)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc)) from None
+    return value
+
+
 def _make_example_command(name: str, info: ExampleInfo) -> None:
     """Create and register a click command for an example."""
     description = info["description"]
@@ -609,12 +629,13 @@ def _make_example_command(name: str, info: ExampleInfo) -> None:
     # Global plot/video options for every example command
     _run = click.option("--video-dpi", "video_dpi", type=int, default=150, show_default=True, help="Video resolution in dots per inch")(_run)
     _run = click.option("--video-fps", "video_fps", type=int, default=60, show_default=True, help="Video frames per second")(_run)
+    _run = click.option("--video-time", "video_time", default=None, callback=_check_video_time, help="Video length in seconds (e.g. 15 or 15s), or a speed to play the plan at (e.g. 100x). Default: 10s")(_run)
     _run = click.option("--save-video", "save_video", default=None, help="Save trajectory animation to file (e.g. out.mp4)")(_run)
     _run = click.option("--show-plot", "show_plot", is_flag=True, default=False, help="Show trajectory plot interactively")(_run)
     _run = click.option("--save-plot", "save_plot", default=None, help="Save trajectory plot to file (e.g. out.png)")(_run)
     # Option group panels (last applied = displayed first)
     _run = click.option_panel("Options", options=[opt["name"] for opt in options] + ["--help"])(_run)
-    _run = click.option_panel("Plot/video options", options=["--save-plot", "--show-plot", "--save-video", "--video-fps", "--video-dpi"])(_run)
+    _run = click.option_panel("Plot/video options", options=["--save-plot", "--show-plot", "--save-video", "--video-time", "--video-fps", "--video-dpi"])(_run)
 
 
 # Register each example as a direct subcommand

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import subprocess
 from typing import Any, Iterable, TYPE_CHECKING
 
@@ -8,6 +9,72 @@ from ._tui import _generate_coordinates, _is_ci_environment
 
 if TYPE_CHECKING:
     from .dashboard import PlannerDashboard
+
+DEFAULT_VIDEO_DURATION = 10.0
+"""Seconds of video when the caller asks for no particular length."""
+
+
+def parse_video_time(spec: float | str) -> tuple[float, bool]:
+    """Split a video-time spec into its number and whether it is a speed.
+
+    ``"15"`` and ``"15s"`` are the same fifteen seconds; the unit is optional
+    because a bare number next to a ``100x`` in the same help text invites the
+    question of what it is. ``"100x"`` is a speed.
+
+    Separate from `resolve_video_duration` so a caller taking the spec from a
+    user -- the CLI -- can reject a typo at the point it was typed, rather
+    than after a planning run it would then throw away.
+
+    Raises:
+        ValueError: on anything that is not a positive number of seconds or a
+            positive ``<number>x`` speed.
+    """
+    text = str(spec).strip()
+    suffix = text[-1:].lower()
+    is_speed = suffix == "x"
+    try:
+        value = float(text[:-1] if is_speed or suffix == "s" else text)
+    except ValueError:
+        raise ValueError(
+            f"cannot read {text!r} as a video time: give seconds ('15' or "
+            f"'15s') or a speed ('100x')"
+        ) from None
+    if not math.isfinite(value):
+        # `float` takes 'inf' and 'nan' happily; the frame count made from
+        # either blows up somewhere much further from what was typed.
+        raise ValueError(f"video time must be a real length, not {text!r}")
+    if value <= 0:
+        noun = "speed" if is_speed else "length"
+        raise ValueError(f"video {noun} must be positive, not {text!r}")
+    return value, is_speed
+
+
+def resolve_video_duration(spec: float | str | None, plan_time: float) -> float:
+    """Seconds of video for *spec*, which is either a length or a speed.
+
+    A number, bare or with an ``s`` on it (``15``, ``"15"``, ``"15s"``), is the
+    length of the finished video in seconds, whatever the plan cost. A string
+    ending in ``x`` -- ``"100x"`` -- is a speed instead: the plan is played
+    that many times faster than it ran, so a plan costing 1500 comes out 15
+    seconds long. Speed is the more useful
+    of the two whenever plans of different sizes have to stay comparable on
+    screen, which a fixed length quietly destroys.
+
+    Raises:
+        ValueError: on a spec `parse_video_time` rejects, and on a speed over
+            a plan that cost nothing, which has no length to scale.
+    """
+    if spec is None:
+        return DEFAULT_VIDEO_DURATION
+    value, is_speed = parse_video_time(spec)
+    if not is_speed:
+        return value
+    duration = float(plan_time) / value
+    if duration <= 0:
+        raise ValueError(
+            f"a plan costing {plan_time:g} has nothing to play at {value:g}x"
+        )
+    return duration
 
 
 def _canvas_buffer_writer_cls() -> Any:
@@ -1119,7 +1186,7 @@ class _PlottingMixin:
         *,
         location_coords: dict[str, tuple[float, float]] | None = None,
         fps: int = 60,
-        duration: float = 10.0,
+        duration: float | str | None = None,
         figsize: tuple[float, float] = (12.8, 7.2),
         dpi: int = 150,
         object_sprites: bool = True,
@@ -1133,7 +1200,11 @@ class _PlottingMixin:
                 ``.mp4``/``.avi`` uses FFMpegWriter.
             location_coords: Optional explicit location->(x,y) mapping.
             fps: Frames per second.
-            duration: Total animation duration in seconds.
+            duration: How long the finished video runs. A number is seconds,
+                with or without an ``s`` on it (``15``, ``"15s"``); a string
+                ending in ``x`` (``"100x"``) is a speed, playing the plan that
+                many times faster than it ran. Defaults to
+                ``DEFAULT_VIDEO_DURATION`` seconds.
             figsize: Figure size in inches.
             dpi: Resolution in dots per inch.
             object_sprites: Animate emoji glyphs for the objects the plan is
@@ -1163,6 +1234,15 @@ class _PlottingMixin:
         if result is None:
             return
         fig, ax, sidebar_ax, trajectories, env_coords, t_end, onboard_axes = result
+
+        # A speed only means something against the plan's own cost, so this is
+        # the first point it can be resolved -- and the last point before the
+        # figure is worth anything, hence closing it rather than leaking one.
+        try:
+            duration = resolve_video_duration(duration, t_end)
+        except ValueError:
+            plt.close(fig)
+            raise
 
         # Render at the output resolution from the start. The frame loop
         # composites straight out of the canvas buffer, so the figure's dpi
@@ -1826,6 +1906,17 @@ class _PlottingMixin:
                     yield frame
                     progress.update(task, completed=frame + 1)
 
+        # Announced before the first frame, because the cost of a video is
+        # not obvious from the flag that asked for it: a speed over a long plan
+        # can quietly run to thousands of frames. Ctrl-C is honoured below and
+        # keeps what has been written, so this is a decision the user can still
+        # act on.
+        self.console.print(
+            f"Writing [bold]{duration:.1f}s[/bold] of video at {fps} fps "
+            f"— {n_frames} frames, {t_end / duration:.3g}x plan speed. "
+            f"Ctrl-C keeps what is written."
+        )
+
         writer = _canvas_buffer_writer_cls()(fps=fps)
 
         interrupted = False
@@ -1933,6 +2024,7 @@ class _PlottingMixin:
         save_video: str | None = None,
         video_fps: int = 60,
         video_dpi: int = 150,
+        video_time: float | str | None = None,
         location_coords: dict[str, tuple[float, float]] | None = None,
         object_sprites: bool = True,
         glyph_objects: Iterable[str] | None = None,
@@ -1946,6 +2038,10 @@ class _PlottingMixin:
             save_video: If set, save a trajectory animation to this file path.
             video_fps: Frames per second for video (default: 60).
             video_dpi: Resolution in dots per inch for video (default: 150).
+            video_time: How long the video runs -- seconds (``15`` or
+                ``"15s"``), or a speed as a string ending in ``x`` (``"100x"``
+                plays the plan a hundred times faster than it ran). Defaults
+                to ``DEFAULT_VIDEO_DURATION`` seconds.
             location_coords: Optional explicit location->(x,y) mapping.
             object_sprites: Draw emoji glyphs for the objects the plan is about.
                 Defaults to drawing them when a glyph source is available.
@@ -1977,7 +2073,7 @@ class _PlottingMixin:
         if save_video:
             self.save_video(
                 save_video, location_coords=location_coords,
-                fps=video_fps, dpi=video_dpi,
+                fps=video_fps, dpi=video_dpi, duration=video_time,
                 object_sprites=object_sprites, glyph_objects=glyph_objects,
                 search_pulses=search_pulses,
             )

--- a/packages/railroad/src/railroad/dashboard/plotting.py
+++ b/packages/railroad/src/railroad/dashboard/plotting.py
@@ -67,6 +67,13 @@ class _PlottingMixin:
     _SPRITE_FADE_FRACTION = 0.02
     _MAX_SPRITES = 12
 
+    _PULSE_ZORDER = 6.0
+    """Search rings: over the trail and the location markers, under the robot.
+
+    The ring comes out of the robot, so the robot has to stay on top of it;
+    under the object glyphs for the same reason.
+    """
+
     _sprite_warned = False
     _sprite_cap_warned = False
     """Set per dashboard, so a two-render call says each of these once."""
@@ -1117,6 +1124,7 @@ class _PlottingMixin:
         dpi: int = 150,
         object_sprites: bool = True,
         glyph_objects: Iterable[str] | None = None,
+        search_pulses: bool = True,
     ) -> None:
         """Save an animated trajectory video/GIF.
 
@@ -1132,6 +1140,8 @@ class _PlottingMixin:
                 about. Defaults to animating them when a glyph source exists.
             glyph_objects: Objects to draw glyphs for, overriding the derived
                 plan-relevant set.
+            search_pulses: Ring an expanding pulse out of a robot while it is
+                searching, so the pause reads as sensing rather than waiting.
         """
         import numpy as np
         import matplotlib as mpl
@@ -1367,6 +1377,35 @@ class _PlottingMixin:
             for x, y in track
         ]
 
+        # Search rings. Sized here, beside the sprites, because the fallback
+        # radius is derived from the axes the same way theirs is, and this is
+        # where the axes have a scale to derive it from.
+        pulse_radii: dict[str, Any] = {}
+        pulse_alpha: dict[str, Any] = {}
+        if search_pulses:
+            from railroad.plotting import pulses as _pulses
+
+            windows = _pulses.search_windows(
+                actions_taken=self.actions_taken,
+                history=self.history,
+                known_robots=self.known_robots,
+                horizon=t_end,
+            )
+            if windows:
+                radius = _pulses.pulse_radius(
+                    ax, getattr(getattr(self._env, "scene", None), "resolution", None),
+                )
+                for robot, robot_windows in _pulses.by_robot(windows).items():
+                    # No interpolated track means no centre to ring; a robot
+                    # that never moved has no trajectory to sample.
+                    if robot not in marker_positions:
+                        continue
+                    radii, alpha = _pulses.sample(
+                        robot_windows, frame_times, radius=radius,
+                    )
+                    if alpha.any():
+                        pulse_radii[robot], pulse_alpha[robot] = radii, alpha
+
         if occupancy_grid is not None:
             # Before label_offset below, which reads ax.get_ylim(). Pinning the
             # limits turns autoscale off, so everything drawn in data
@@ -1458,6 +1497,7 @@ class _PlottingMixin:
         # Above the trail so they read over it, below the robot marker so a
         # carried object never hides its carrier. Animated, and composited by
         # hand each frame along with the markers.
+        from railroad.plotting.pulses import make_ring, update_ring
         from railroad.plotting.sprites import make_sprite, update_sprite
 
         sprite_artists: dict[str, tuple[Any, Any]] = {}
@@ -1467,6 +1507,16 @@ class _PlottingMixin:
                 ax, rgba, (float(first[0]), float(first[1])),
                 zorder=self._SPRITE_ZORDER, animated=True,
             )
+
+        # One ring per searching robot: it can only be busy with one search at
+        # a time, so the artist is reused across that robot's whole plan.
+        pulse_artists: dict[str, Any] = {
+            robot: make_ring(
+                ax, marker_positions[robot][0],
+                zorder=self._PULSE_ZORDER, animated=True,
+            )
+            for robot in sorted(pulse_radii)
+        }
 
         legend_artist = ax.legend(fontsize=7, loc="upper right")
         # Fixed-width title so it doesn't jump during animation
@@ -1562,6 +1612,16 @@ class _PlottingMixin:
                     box, offset_image, sprite_rgba[name],
                     sprite_xy[name][frame], alpha,
                 )
+            for robot, ring in pulse_artists.items():
+                alpha = float(pulse_alpha[robot][frame])
+                # Hidden rather than transparent, as for the sprites: a robot
+                # that is not searching costs nothing to skip.
+                ring.set_visible(alpha > 0.0)
+                if alpha > 0.0:
+                    update_ring(
+                        ring, marker_positions[robot][frame],
+                        float(pulse_radii[robot][frame]), alpha,
+                    )
             # Trail points up to the current time. combined_times is sorted,
             # so the visible set is always a prefix.
             n_trail = int(np.searchsorted(combined_times, current_time, side="right"))
@@ -1610,7 +1670,8 @@ class _PlottingMixin:
         # skips them and leaves them to be composited in the right order.
         sprite_boxes = [box for box, _image in sprite_artists.values()]
         hot_artists: list[Any] = [
-            *markers, *labels, *sprite_boxes, title_artist, legend_artist,
+            *markers, *labels, *sprite_boxes, *pulse_artists.values(),
+            title_artist, legend_artist,
         ]
         # Draw them in the same order a full figure draw would, so anything
         # that overlaps still stacks the way it does in the static plot.
@@ -1875,6 +1936,7 @@ class _PlottingMixin:
         location_coords: dict[str, tuple[float, float]] | None = None,
         object_sprites: bool = True,
         glyph_objects: Iterable[str] | None = None,
+        search_pulses: bool = True,
     ) -> None:
         """Convenience method that handles plot/video output based on CLI flags.
 
@@ -1889,6 +1951,9 @@ class _PlottingMixin:
                 Defaults to drawing them when a glyph source is available.
             glyph_objects: Objects to draw glyphs for, overriding the derived
                 plan-relevant set.
+            search_pulses: Ring a pulse out of a searching robot in the video.
+                The static plot has no instant at which a search is running,
+                so it is unaffected.
         """
         if not save_plot and not show_plot and not save_video:
             return
@@ -1914,5 +1979,6 @@ class _PlottingMixin:
                 save_video, location_coords=location_coords,
                 fps=video_fps, dpi=video_dpi,
                 object_sprites=object_sprites, glyph_objects=glyph_objects,
+                search_pulses=search_pulses,
             )
             self.console.print(f"Saved video to [yellow]{save_video}[/yellow]")

--- a/packages/railroad/src/railroad/examples/clear_the_table.py
+++ b/packages/railroad/src/railroad/examples/clear_the_table.py
@@ -50,6 +50,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run the clear-the-table example."""
     # Objects that need to be cleared from the table
@@ -128,7 +129,7 @@ def main(
     location_coords = {name: (float(c[0]), float(c[1])) for name, c in LOCATIONS.items()}
     dashboard.show_plots(
         save_plot=save_plot, show_plot=show_plot, save_video=save_video,
-        video_fps=video_fps, video_dpi=video_dpi,
+        video_fps=video_fps, video_dpi=video_dpi, video_time=video_time,
         location_coords=location_coords,
     )
 

--- a/packages/railroad/src/railroad/examples/find_and_move_couch.py
+++ b/packages/railroad/src/railroad/examples/find_and_move_couch.py
@@ -51,6 +51,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run the find-and-move-couch example."""
     # Define the objects we're looking for
@@ -134,7 +135,7 @@ def main(
     location_coords = {name: (float(c[0]), float(c[1])) for name, c in LOCATIONS.items()}
     dashboard.show_plots(
         save_plot=save_plot, show_plot=show_plot, save_video=save_video,
-        video_fps=video_fps, video_dpi=video_dpi,
+        video_fps=video_fps, video_dpi=video_dpi, video_time=video_time,
         location_coords=location_coords,
     )
 

--- a/packages/railroad/src/railroad/examples/frontier_search.py
+++ b/packages/railroad/src/railroad/examples/frontier_search.py
@@ -29,6 +29,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run frontier-based exploration and object search."""
     from functools import reduce
@@ -209,6 +210,7 @@ def main(
         save_video=save_video,
         video_fps=video_fps,
         video_dpi=video_dpi,
+        video_time=video_time,
     )
 
 

--- a/packages/railroad/src/railroad/examples/heterogeneous_robots.py
+++ b/packages/railroad/src/railroad/examples/heterogeneous_robots.py
@@ -96,6 +96,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run the heterogeneous robots example.
 
@@ -192,7 +193,7 @@ def main(
     location_coords = {name: (float(c[0]), float(c[1])) for name, c in LOCATIONS.items()}
     dashboard.show_plots(
         save_plot=save_plot, show_plot=show_plot, save_video=save_video,
-        video_fps=video_fps, video_dpi=video_dpi,
+        video_fps=video_fps, video_dpi=video_dpi, video_time=video_time,
         location_coords=location_coords,
     )
 

--- a/packages/railroad/src/railroad/examples/lsp_point_goal_nav.py
+++ b/packages/railroad/src/railroad/examples/lsp_point_goal_nav.py
@@ -55,6 +55,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run point-goal navigation with LSP frontier actions."""
     from railroad.core import get_action_by_name
@@ -168,6 +169,7 @@ def main(
         save_video=save_video,
         video_fps=video_fps,
         video_dpi=video_dpi,
+        video_time=video_time,
     )
 
     scene.release()

--- a/packages/railroad/src/railroad/examples/multi_object_search.py
+++ b/packages/railroad/src/railroad/examples/multi_object_search.py
@@ -51,6 +51,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run the multi-object search example."""
     # Define the objects we're looking for
@@ -135,7 +136,7 @@ def main(
     location_coords = {name: (float(c[0]), float(c[1])) for name, c in LOCATIONS.items()}
     dashboard.show_plots(
         save_plot=save_plot, show_plot=show_plot, save_video=save_video,
-        video_fps=video_fps, video_dpi=video_dpi,
+        video_fps=video_fps, video_dpi=video_dpi, video_time=video_time,
         location_coords=location_coords,
     )
 

--- a/packages/railroad/src/railroad/examples/procthor_search.py
+++ b/packages/railroad/src/railroad/examples/procthor_search.py
@@ -39,6 +39,7 @@ def main(
     nn_model_path: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run ProcTHOR multi-robot search example."""
     from railroad.environment.procthor import ProcTHOREnvironment
@@ -165,7 +166,7 @@ def main(
 
     dashboard.show_plots(
         save_plot=save_plot, show_plot=show_plot, save_video=save_video,
-        video_fps=video_fps, video_dpi=video_dpi,
+        video_fps=video_fps, video_dpi=video_dpi, video_time=video_time,
     )
 
 

--- a/packages/railroad/src/railroad/examples/visual_frontier_search.py
+++ b/packages/railroad/src/railroad/examples/visual_frontier_search.py
@@ -30,6 +30,7 @@ def main(
     save_video: str | None = None,
     video_fps: int = 60,
     video_dpi: int = 150,
+    video_time: float | str | None = None,
 ) -> None:
     """Run frontier exploration with panoramic image collection."""
     from functools import reduce
@@ -265,6 +266,7 @@ def main(
         save_video=save_video,
         video_fps=video_fps,
         video_dpi=video_dpi,
+        video_time=video_time,
     )
 
     scene.release()

--- a/packages/railroad/src/railroad/plotting/pulses.py
+++ b/packages/railroad/src/railroad/plotting/pulses.py
@@ -1,0 +1,190 @@
+"""Search pulses: an expanding ring showing that a robot is sensing.
+
+A search is the one action a robot spends real time on while standing still,
+so on the map it is indistinguishable from waiting. The ring is that missing
+signal: it leaves the robot small and opaque, widens to `PULSE_RADIUS_M` and
+fades out as the search runs, so its size reads as how far through the action
+the robot is.
+
+Like the object glyphs next door, the whole thing comes out of the snapshots
+the dashboard already keeps -- no new capture hook.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+Coord = tuple[float, float]
+
+PULSE_RADIUS_M = 1.0
+"""How far a ring travels from the robot by the end of the search, in metres."""
+
+PULSE_MIN_FRACTION = 0.12
+"""Radius the ring starts at, as a fraction of its final one.
+
+Starting from exactly zero spends the opening frames on a ring too small to
+resolve, which reads as the pulse arriving late rather than as it growing.
+"""
+
+PULSE_LINEWIDTH_PT = 1.6
+"""Stroke width of the ring, in points."""
+
+SEARCH_ACTION_PREFIX = "search"
+"""Prefix an action's head token must have to be drawn as a search.
+
+A prefix rather than an equality so `search-frontier` counts alongside
+`search`; keying on the name is the same convention the rest of the
+object-search machinery uses for `searched`, `found` and `free`.
+"""
+
+
+@dataclass(frozen=True)
+class SearchWindow:
+    """When one robot was busy searching."""
+
+    robot: str
+    start: float
+    end: float
+
+
+def _holds_free(fluents: Iterable[Any], robot: str) -> bool:
+    for fluent in fluents:
+        args: Sequence[str] = getattr(fluent, "args", ())
+        if getattr(fluent, "name", None) == "free" and args and args[0] == robot:
+            return True
+    return False
+
+
+def search_windows(
+    *,
+    actions_taken: Iterable[tuple[str, float]],
+    history: Iterable[dict],
+    known_robots: set[str],
+    horizon: float,
+) -> list[SearchWindow]:
+    """The intervals each robot spent searching, from the plan's own record.
+
+    A search dispatch takes the robot's `free` away and its completion gives it
+    back, so the window is bounded by the next snapshot in which the robot is
+    free again. That is exact rather than approximate: `act()` returns whenever
+    *a* robot frees, so the search's own completion is always a snapshot -- and
+    nothing can free the robot earlier, because it is busy. Keying on `free`
+    rather than on `searched` also covers `search-frontier`, which records its
+    result under a different predicate.
+
+    A search still in flight when the plan ended has no such snapshot, and runs
+    to *horizon*: the ring is then cut short with the video, which is what
+    happened to the search.
+    """
+    entries = sorted(
+        (float(entry["time"]), entry.get("fluents", ()))
+        for entry in history
+    )
+    windows: list[SearchWindow] = []
+    for action, dispatched in actions_taken:
+        parts = action.split()
+        if not parts or not parts[0].startswith(SEARCH_ACTION_PREFIX):
+            continue
+        robot = next((part for part in parts[1:] if part in known_robots), None)
+        if robot is None:
+            continue
+        start = float(dispatched)
+        end = next(
+            (
+                time
+                for time, fluents in entries
+                if time > start and _holds_free(fluents, robot)
+            ),
+            float(horizon),
+        )
+        if end > start:
+            windows.append(SearchWindow(robot, start, end))
+    return windows
+
+
+def by_robot(windows: Iterable[SearchWindow]) -> dict[str, list[SearchWindow]]:
+    grouped: dict[str, list[SearchWindow]] = {}
+    for window in windows:
+        grouped.setdefault(window.robot, []).append(window)
+    return grouped
+
+
+def sample(
+    windows: Iterable[SearchWindow], times: Any, *, radius: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Ring radius and opacity at each of *times*, for one robot's windows.
+
+    Both are zero outside every window, which is what hides the artist. A
+    robot cannot search twice at once -- it is not free in between -- so the
+    windows never overlap and the order they are applied in does not matter.
+    """
+    query = np.asarray(times, dtype=float).reshape(-1)
+    radii = np.zeros_like(query)
+    alpha = np.zeros_like(query)
+    for window in windows:
+        span = window.end - window.start
+        if span <= 0:
+            continue
+        live = (query >= window.start) & (query < window.end)
+        progress = (query[live] - window.start) / span
+        radii[live] = radius * (
+            PULSE_MIN_FRACTION + (1.0 - PULSE_MIN_FRACTION) * progress
+        )
+        alpha[live] = 1.0 - progress
+    return radii, alpha
+
+
+def pulse_radius(ax: Any, resolution: float | None) -> float:
+    """`PULSE_RADIUS_M` in the data units the axes are drawn in.
+
+    Plots are drawn in grid cells, so the metre figure only means something
+    where the scene reports a cell size. Without one -- a symbolic domain laid
+    out in whatever coordinates its locations were given -- fall back to the
+    screen-derived length the sprite fan already uses, so the ring stays
+    legible at a scale no metre constant can predict.
+    """
+    if resolution:
+        return PULSE_RADIUS_M / float(resolution)
+    from .sprites import ring_radius, sprite_extent
+
+    return ring_radius(1, sprite_extent(ax))
+
+
+def make_ring(ax: Any, center: Coord, *, zorder: float, animated: bool = False) -> Any:
+    """A white, unfilled ring parked at *center*, hidden until a search runs.
+
+    Parked on the robot rather than at the origin because `add_patch` folds the
+    patch into the axes' data limits, and a stray point at (0, 0) would drag
+    the view of a symbolic plot out to meet it.
+    """
+    from matplotlib.patches import Circle
+
+    ring = Circle(
+        (float(center[0]), float(center[1])), 0.0,
+        fill=False, edgecolor="white", linewidth=PULSE_LINEWIDTH_PT,
+        zorder=zorder, visible=False,
+    )
+    ring.set_animated(animated)
+    ax.add_patch(ring)
+    return ring
+
+
+def update_ring(ring: Any, center: Any, radius: float, alpha: float) -> None:
+    ring.set_center((float(center[0]), float(center[1])))
+    ring.set_radius(float(radius))
+    ring.set_alpha(float(alpha))
+
+
+__all__ = [
+    "PULSE_RADIUS_M",
+    "SearchWindow",
+    "by_robot",
+    "make_ring",
+    "pulse_radius",
+    "sample",
+    "search_windows",
+    "update_ring",
+]

--- a/packages/railroad/tests/plotting/test_search_pulses.py
+++ b/packages/railroad/tests/plotting/test_search_pulses.py
@@ -1,0 +1,158 @@
+"""The search ring's timing, geometry and scale."""
+
+import numpy as np
+import pytest
+
+from railroad.core import Fluent as F
+from railroad.plotting.pulses import (
+    PULSE_MIN_FRACTION,
+    PULSE_RADIUS_M,
+    SearchWindow,
+    by_robot,
+    pulse_radius,
+    sample,
+    search_windows,
+)
+
+ROBOTS = {"r1", "r2"}
+
+
+def entry(time, *fluents):
+    return {"time": time, "fluents": {F(value) for value in fluents}}
+
+
+def windows(actions, history, *, horizon=100.0, known_robots=ROBOTS):
+    return search_windows(
+        actions_taken=actions, history=history,
+        known_robots=known_robots, horizon=horizon,
+    )
+
+
+class TestSearchWindows:
+    def test_runs_from_dispatch_to_the_snapshot_that_frees_the_robot(self):
+        assert windows(
+            [("search r1 shelf mug", 0.0)],
+            [entry(0, "free r1"), entry(4, "at r1 shelf"), entry(10, "free r1")],
+        ) == [SearchWindow("r1", 0.0, 10.0)]
+
+    def test_the_dispatch_snapshot_does_not_end_the_window_it_starts(self):
+        """`free r1` is still in the state the action was chosen from.
+
+        The dashboard records an action against the time of the state
+        *before* it ran, which is the last one in which the robot was free.
+        Matching that snapshot would collapse every window to nothing.
+        """
+        assert windows(
+            [("search r1 shelf mug", 4.0)],
+            [entry(4, "free r1"), entry(14, "free r1")],
+        ) == [SearchWindow("r1", 4.0, 14.0)]
+
+    def test_another_robot_freeing_mid_search_does_not_end_it(self):
+        assert windows(
+            [("search r1 shelf mug", 0.0)],
+            [entry(0, "free r1", "free r2"), entry(3, "free r2"), entry(9, "free r1")],
+        ) == [SearchWindow("r1", 0.0, 9.0)]
+
+    def test_a_search_still_running_at_the_end_runs_to_the_horizon(self):
+        assert windows(
+            [("search r1 shelf mug", 20.0)],
+            [entry(0, "free r1"), entry(20, "free r1"), entry(26, "at r1 shelf")],
+            horizon=26.0,
+        ) == [SearchWindow("r1", 20.0, 26.0)]
+
+    def test_search_frontier_counts_too(self):
+        """Its result lands under `searched-frontier`, but `free` is `free`."""
+        assert windows(
+            [("search-frontier r1 frontier_2 mug", 0.0)],
+            [entry(0, "free r1"), entry(5, "free r1")],
+        ) == [SearchWindow("r1", 0.0, 5.0)]
+
+    @pytest.mark.parametrize(
+        "action", ["move r1 shelf counter", "pick r1 shelf mug", "researched r1 shelf"],
+    )
+    def test_other_actions_are_ignored(self, action):
+        assert windows([(action, 0.0)], [entry(5, "free r1")]) == []
+
+    def test_an_action_naming_no_known_robot_is_ignored(self):
+        assert windows(
+            [("search ghost shelf mug", 0.0)], [entry(5, "free ghost")],
+        ) == []
+
+    def test_each_search_gets_its_own_window(self):
+        assert windows(
+            [("search r1 shelf mug", 0.0), ("search r1 counter mug", 12.0)],
+            [entry(0, "free r1"), entry(10, "free r1"), entry(12, "free r1"),
+             entry(22, "free r1")],
+        ) == [SearchWindow("r1", 0.0, 10.0), SearchWindow("r1", 12.0, 22.0)]
+
+    def test_windows_group_by_robot(self):
+        grouped = by_robot(
+            windows(
+                [("search r1 shelf mug", 0.0), ("search r2 counter mug", 0.0)],
+                [entry(0, "free r1", "free r2"), entry(6, "free r2"),
+                 entry(10, "free r1")],
+            )
+        )
+        assert grouped == {
+            "r1": [SearchWindow("r1", 0.0, 10.0)],
+            "r2": [SearchWindow("r2", 0.0, 6.0)],
+        }
+
+
+class TestSample:
+    WINDOW = SearchWindow("r1", 10.0, 20.0)
+
+    def test_grows_from_small_to_full_and_fades_as_it_goes(self):
+        radii, alpha = sample(
+            [self.WINDOW], [10.0, 15.0, 19.999], radius=4.0,
+        )
+        assert radii[0] == pytest.approx(4.0 * PULSE_MIN_FRACTION)
+        assert radii[-1] == pytest.approx(4.0, rel=1e-3)
+        assert list(radii) == sorted(radii)
+        assert alpha[0] == pytest.approx(1.0)
+        assert alpha[-1] == pytest.approx(0.0, abs=1e-3)
+
+    def test_is_invisible_outside_the_window(self):
+        radii, alpha = sample([self.WINDOW], [0.0, 9.99, 20.0, 40.0], radius=4.0)
+        assert not radii.any()
+        assert not alpha.any()
+
+    def test_a_degenerate_window_draws_nothing(self):
+        radii, alpha = sample(
+            [SearchWindow("r1", 5.0, 5.0)], [4.0, 5.0, 6.0], radius=4.0,
+        )
+        assert not radii.any() and not alpha.any()
+
+    def test_consecutive_windows_each_restart_the_ring(self):
+        radii, _alpha = sample(
+            [SearchWindow("r1", 0.0, 10.0), SearchWindow("r1", 10.0, 20.0)],
+            [9.0, 10.0], radius=4.0,
+        )
+        assert radii[1] < radii[0], "the second search starts a new, small ring"
+
+    def test_no_windows_leaves_every_frame_hidden(self):
+        radii, alpha = sample([], np.linspace(0.0, 10.0, 5), radius=4.0)
+        assert radii.shape == alpha.shape == (5,)
+        assert not radii.any() and not alpha.any()
+
+
+class TestRadius:
+    def test_metres_become_cells_through_the_scene_resolution(self):
+        assert pulse_radius(None, 0.05) == pytest.approx(PULSE_RADIUS_M / 0.05)
+
+    def test_without_a_resolution_it_falls_back_to_the_axes_scale(self):
+        """A symbolic plot has no metres, so the ring is sized on screen."""
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        from railroad.plotting.sprites import ring_radius, sprite_extent
+
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([0.0, 40.0], [0.0, 40.0])
+            expected = ring_radius(1, sprite_extent(ax))
+            assert pulse_radius(ax, None) == pytest.approx(expected)
+            assert expected > 0.0
+        finally:
+            plt.close(fig)

--- a/packages/railroad/tests/plotting/test_search_pulses.py
+++ b/packages/railroad/tests/plotting/test_search_pulses.py
@@ -1,6 +1,5 @@
 """The search ring's timing, geometry and scale."""
 
-import numpy as np
 import pytest
 
 from railroad.core import Fluent as F
@@ -21,138 +20,91 @@ def entry(time, *fluents):
     return {"time": time, "fluents": {F(value) for value in fluents}}
 
 
-def windows(actions, history, *, horizon=100.0, known_robots=ROBOTS):
+def windows(actions, history, *, horizon=100.0):
     return search_windows(
         actions_taken=actions, history=history,
-        known_robots=known_robots, horizon=horizon,
+        known_robots=ROBOTS, horizon=horizon,
     )
 
 
-class TestSearchWindows:
-    def test_runs_from_dispatch_to_the_snapshot_that_frees_the_robot(self):
-        assert windows(
-            [("search r1 shelf mug", 0.0)],
-            [entry(0, "free r1"), entry(4, "at r1 shelf"), entry(10, "free r1")],
-        ) == [SearchWindow("r1", 0.0, 10.0)]
+@pytest.mark.parametrize(
+    "action", ["search r1 shelf mug", "search-frontier r1 frontier_2 mug"],
+)
+def test_a_window_runs_from_dispatch_to_the_snapshot_that_frees_the_robot(action):
+    """Three traps in one history.
 
-    def test_the_dispatch_snapshot_does_not_end_the_window_it_starts(self):
-        """`free r1` is still in the state the action was chosen from.
+    The dispatch snapshot still holds `free r1` -- the dashboard records an
+    action against the state it was chosen *from* -- and matching it would
+    collapse every window to nothing. r2 freeing partway through must not end
+    r1's search either. And `search-frontier` files its result under its own
+    predicate, which is why the window keys on `free`.
+    """
+    assert windows(
+        [(action, 0.0)],
+        [entry(0, "free r1", "free r2"), entry(3, "free r2"), entry(10, "free r1")],
+    ) == [SearchWindow("r1", 0.0, 10.0)]
 
-        The dashboard records an action against the time of the state
-        *before* it ran, which is the last one in which the robot was free.
-        Matching that snapshot would collapse every window to nothing.
-        """
-        assert windows(
-            [("search r1 shelf mug", 4.0)],
-            [entry(4, "free r1"), entry(14, "free r1")],
-        ) == [SearchWindow("r1", 4.0, 14.0)]
 
-    def test_another_robot_freeing_mid_search_does_not_end_it(self):
-        assert windows(
-            [("search r1 shelf mug", 0.0)],
-            [entry(0, "free r1", "free r2"), entry(3, "free r2"), entry(9, "free r1")],
-        ) == [SearchWindow("r1", 0.0, 9.0)]
+def test_a_search_still_running_at_the_end_runs_to_the_horizon():
+    assert windows(
+        [("search r1 shelf mug", 20.0)],
+        [entry(20, "free r1"), entry(26, "at r1 shelf")], horizon=26.0,
+    ) == [SearchWindow("r1", 20.0, 26.0)]
 
-    def test_a_search_still_running_at_the_end_runs_to_the_horizon(self):
-        assert windows(
-            [("search r1 shelf mug", 20.0)],
-            [entry(0, "free r1"), entry(20, "free r1"), entry(26, "at r1 shelf")],
-            horizon=26.0,
-        ) == [SearchWindow("r1", 20.0, 26.0)]
 
-    def test_search_frontier_counts_too(self):
-        """Its result lands under `searched-frontier`, but `free` is `free`."""
-        assert windows(
-            [("search-frontier r1 frontier_2 mug", 0.0)],
-            [entry(0, "free r1"), entry(5, "free r1")],
-        ) == [SearchWindow("r1", 0.0, 5.0)]
+def test_every_search_gets_a_window_and_nothing_else_does():
+    """Two robots, one of them searching twice, and two actions to ignore."""
+    assert by_robot(
+        windows(
+            [("search r1 shelf mug", 0.0), ("search r2 counter mug", 0.0),
+             ("move r1 shelf counter", 4.0), ("search ghost shelf mug", 4.0),
+             ("search r1 counter mug", 10.0)],
+            [entry(0, "free r1", "free r2"), entry(6, "free r2"),
+             entry(10, "free r1"), entry(22, "free r1")],
+        )
+    ) == {
+        "r1": [SearchWindow("r1", 0.0, 10.0), SearchWindow("r1", 10.0, 22.0)],
+        "r2": [SearchWindow("r2", 0.0, 6.0)],
+    }
 
-    @pytest.mark.parametrize(
-        "action", ["move r1 shelf counter", "pick r1 shelf mug", "researched r1 shelf"],
+
+def test_the_ring_grows_and_fades_over_the_search_and_is_hidden_outside_it():
+    radii, alpha = sample(
+        [SearchWindow("r1", 10.0, 20.0)],
+        [9.99, 10.0, 15.0, 19.999, 20.0], radius=4.0,
     )
-    def test_other_actions_are_ignored(self, action):
-        assert windows([(action, 0.0)], [entry(5, "free r1")]) == []
-
-    def test_an_action_naming_no_known_robot_is_ignored(self):
-        assert windows(
-            [("search ghost shelf mug", 0.0)], [entry(5, "free ghost")],
-        ) == []
-
-    def test_each_search_gets_its_own_window(self):
-        assert windows(
-            [("search r1 shelf mug", 0.0), ("search r1 counter mug", 12.0)],
-            [entry(0, "free r1"), entry(10, "free r1"), entry(12, "free r1"),
-             entry(22, "free r1")],
-        ) == [SearchWindow("r1", 0.0, 10.0), SearchWindow("r1", 12.0, 22.0)]
-
-    def test_windows_group_by_robot(self):
-        grouped = by_robot(
-            windows(
-                [("search r1 shelf mug", 0.0), ("search r2 counter mug", 0.0)],
-                [entry(0, "free r1", "free r2"), entry(6, "free r2"),
-                 entry(10, "free r1")],
-            )
-        )
-        assert grouped == {
-            "r1": [SearchWindow("r1", 0.0, 10.0)],
-            "r2": [SearchWindow("r2", 0.0, 6.0)],
-        }
+    assert (radii[0], alpha[0]) == (0.0, 0.0), "nothing before the search"
+    assert (radii[-1], alpha[-1]) == (0.0, 0.0), "nothing after it"
+    assert radii[1] == pytest.approx(4.0 * PULSE_MIN_FRACTION)
+    assert radii[3] == pytest.approx(4.0, rel=1e-3)
+    assert list(radii[1:4]) == sorted(radii[1:4])
+    assert alpha[1] == pytest.approx(1.0)
+    assert alpha[3] == pytest.approx(0.0, abs=1e-3)
 
 
-class TestSample:
-    WINDOW = SearchWindow("r1", 10.0, 20.0)
-
-    def test_grows_from_small_to_full_and_fades_as_it_goes(self):
-        radii, alpha = sample(
-            [self.WINDOW], [10.0, 15.0, 19.999], radius=4.0,
-        )
-        assert radii[0] == pytest.approx(4.0 * PULSE_MIN_FRACTION)
-        assert radii[-1] == pytest.approx(4.0, rel=1e-3)
-        assert list(radii) == sorted(radii)
-        assert alpha[0] == pytest.approx(1.0)
-        assert alpha[-1] == pytest.approx(0.0, abs=1e-3)
-
-    def test_is_invisible_outside_the_window(self):
-        radii, alpha = sample([self.WINDOW], [0.0, 9.99, 20.0, 40.0], radius=4.0)
-        assert not radii.any()
-        assert not alpha.any()
-
-    def test_a_degenerate_window_draws_nothing(self):
-        radii, alpha = sample(
-            [SearchWindow("r1", 5.0, 5.0)], [4.0, 5.0, 6.0], radius=4.0,
-        )
-        assert not radii.any() and not alpha.any()
-
-    def test_consecutive_windows_each_restart_the_ring(self):
-        radii, _alpha = sample(
-            [SearchWindow("r1", 0.0, 10.0), SearchWindow("r1", 10.0, 20.0)],
-            [9.0, 10.0], radius=4.0,
-        )
-        assert radii[1] < radii[0], "the second search starts a new, small ring"
-
-    def test_no_windows_leaves_every_frame_hidden(self):
-        radii, alpha = sample([], np.linspace(0.0, 10.0, 5), radius=4.0)
-        assert radii.shape == alpha.shape == (5,)
-        assert not radii.any() and not alpha.any()
+@pytest.mark.parametrize(
+    "searches", [[SearchWindow("r1", 5.0, 5.0)], []],
+    ids=["a window of no length", "no search at all"],
+)
+def test_nothing_is_drawn_when_there_is_no_search_to_draw(searches):
+    radii, alpha = sample(searches, [4.0, 5.0, 6.0], radius=4.0)
+    assert radii.shape == alpha.shape == (3,)
+    assert not radii.any() and not alpha.any()
 
 
-class TestRadius:
-    def test_metres_become_cells_through_the_scene_resolution(self):
-        assert pulse_radius(None, 0.05) == pytest.approx(PULSE_RADIUS_M / 0.05)
+def test_metres_become_cells_through_the_scene_resolution():
+    assert pulse_radius(None, 0.05) == pytest.approx(PULSE_RADIUS_M / 0.05)
 
-    def test_without_a_resolution_it_falls_back_to_the_axes_scale(self):
-        """A symbolic plot has no metres, so the ring is sized on screen."""
-        matplotlib = pytest.importorskip("matplotlib")
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
 
-        from railroad.plotting.sprites import ring_radius, sprite_extent
+def test_without_a_resolution_the_ring_is_sized_on_screen():
+    """A symbolic plot has no metres, so there is nothing to convert."""
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
 
-        fig, ax = plt.subplots()
-        try:
-            ax.plot([0.0, 40.0], [0.0, 40.0])
-            expected = ring_radius(1, sprite_extent(ax))
-            assert pulse_radius(ax, None) == pytest.approx(expected)
-            assert expected > 0.0
-        finally:
-            plt.close(fig)
+    fig, ax = plt.subplots()
+    try:
+        ax.plot([0.0, 40.0], [0.0, 40.0])
+        assert 0.0 < pulse_radius(ax, None) < 40.0
+    finally:
+        plt.close(fig)

--- a/packages/railroad/tests/test_video_compositing.py
+++ b/packages/railroad/tests/test_video_compositing.py
@@ -389,3 +389,125 @@ class TestObjectSpritesSurviveCompositing:
         assert xs == sorted(xs), "the carried sprite should travel with the robot"
         assert xs[-1] - xs[0] > 50, "it barely moved"
         assert max(areas) < 1.5 * min(areas), f"sprite area grew: {areas}"
+
+
+@pytest.mark.skipif(not _have_ffmpeg(), reason="ffmpeg not installed")
+class TestSearchPulseSurvivesCompositing:
+    """The search ring, end to end through the compositing loop.
+
+    The ring is a hot artist over a cached raster, like the markers and the
+    glyphs, so it fails the same way they do: composited in the wrong order it
+    is either invisible or smeared over the frames that follow. It is
+    recoloured for the test because white is a design choice and unfindable on
+    the plot's own white ground -- what is asserted is that it reaches the
+    buffer, in the frames it should and no others.
+    """
+
+    #: r1 searches the shelf for 10s, then walks 10s to the counter.
+    PLAN = ("search r1 shelf mug", "move r1 shelf counter")
+    FPS, DURATION, T_END = 8, 2.0, 20.0
+
+    #: Frame 0 repeats the finished plan; 1-15 sample it evenly. The search
+    #: covers 1-8, but by 7 the ring has faded to nothing a codec can carry,
+    #: so the tail is left untested rather than pinned to a fading threshold.
+    SEARCHING = slice(1, 7)
+    AFTERWARDS = slice(9, None)
+
+    #: Chroma the ring has to beat. H.264 tints flat white by up to ~25.
+    CHROMA = 40
+
+    @pytest.fixture
+    def green_ring(self, monkeypatch):
+        from railroad.plotting import pulses
+
+        make_ring = pulses.make_ring
+
+        def coloured(*args, **kwargs):
+            ring = make_ring(*args, **kwargs)
+            ring.set_edgecolor("#00ff00")
+            return ring
+
+        monkeypatch.setattr(pulses, "make_ring", coloured)
+
+    @pytest.fixture
+    def dashboard(self):
+        from railroad import operators
+        from railroad._bindings import State
+        from railroad.core import Fluent as F, get_action_by_name
+        from railroad.dashboard import PlannerDashboard
+        from railroad.environment import ObjectSearchEnvironment
+        from railroad.plotting.pulses import PULSE_RADIUS_M
+
+        class Scene:
+            #: Metres per cell, sized so the full ring is 10 cells across this
+            #: 40x30 map -- clear of the frame, which would clip its growth.
+            resolution = PULSE_RADIUS_M / 10.0
+
+        class SearchEnvironment(ObjectSearchEnvironment):
+            def define_operators(self):
+                return [
+                    operators.construct_search_operator(1.0, 10.0),
+                    operators.construct_move_operator_blocking(
+                        lambda r, a, b: 10.0
+                    ),
+                ]
+
+        env = SearchEnvironment(
+            state=State(0.0, {F("at r1 shelf"), F("free r1")}, []),
+            objects_by_type={
+                "robot": {"r1"},
+                "location": {"shelf", "counter"},
+                "object": {"mug"},
+            },
+            true_object_locations={"shelf": set(), "counter": {"mug"}},
+        )
+        env.occupancy_grid = np.zeros((40, 30))  # ty: ignore[unresolved-attribute]
+        env.scene = Scene()  # ty: ignore[unresolved-attribute]
+
+        dashboard = PlannerDashboard(
+            F("found mug"), env, force_interactive=False, print_on_exit=False,
+        )
+        with dashboard:
+            for name in self.PLAN:
+                env.act(get_action_by_name(env.get_actions(), name))
+                dashboard._do_update(env.state, last_action_name=name)
+        return dashboard
+
+    @pytest.fixture
+    def spans(self, dashboard, tmp_path, green_ring):
+        """The ring's width in pixels for each frame, 0.0 where undrawn."""
+        import subprocess
+
+        out = tmp_path / "pulses.mp4"
+        dashboard.save_video(
+            str(out),
+            location_coords={"shelf": (10.0, 15.0), "counter": (32.0, 8.0)},
+            fps=self.FPS, duration=self.DURATION, figsize=(6.0, 4.0), dpi=100,
+        )
+        subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", str(out), str(tmp_path / "f%02d.png")],
+            check=True, capture_output=True,
+        )
+        return [self._span(frame) for frame in sorted(tmp_path.glob("f*.png"))]
+
+    @classmethod
+    def _span(cls, path) -> float:
+        from PIL import Image
+
+        pixels = np.asarray(Image.open(path).convert("RGB")).astype(int)
+        green = pixels[..., 1] - np.maximum(pixels[..., 0], pixels[..., 2])
+        drawn = green > cls.CHROMA
+        if not drawn.any():
+            return 0.0
+        cols = np.nonzero(drawn)[1]
+        return float(cols.max() - cols.min())
+
+    def test_the_ring_radiates_while_the_robot_searches(self, spans):
+        searching = spans[self.SEARCHING]
+        assert all(searching), f"no ring drawn during the search: {spans}"
+        assert searching == sorted(searching), f"the ring did not grow: {spans}"
+        assert searching[-1] > 3 * searching[0], f"it barely grew: {spans}"
+
+    def test_the_ring_is_absent_before_the_search_and_after_it(self, spans):
+        assert not spans[0], f"the poster frame has no search running: {spans}"
+        assert not any(spans[self.AFTERWARDS]), f"the ring outlived it: {spans}"

--- a/packages/railroad/tests/test_video_compositing.py
+++ b/packages/railroad/tests/test_video_compositing.py
@@ -391,79 +391,66 @@ class TestObjectSpritesSurviveCompositing:
         assert max(areas) < 1.5 * min(areas), f"sprite area grew: {areas}"
 
 
+
 @pytest.mark.skipif(not _have_ffmpeg(), reason="ffmpeg not installed")
 class TestSearchPulseSurvivesCompositing:
     """The search ring, end to end through the compositing loop.
 
     The ring is a hot artist over a cached raster, like the markers and the
-    glyphs, so it fails the same way they do: composited in the wrong order it
-    is either invisible or smeared over the frames that follow. It is
-    recoloured for the test because white is a design choice and unfindable on
-    the plot's own white ground -- what is asserted is that it reaches the
-    buffer, in the frames it should and no others.
+    glyphs, so it fails the same way they do: composited wrongly it is either
+    invisible or smeared across the frames that follow. Whether it grows on the
+    right curve is settled in the unit tests; what is asserted here is only
+    that it reaches the buffer, in the frames it should and no others. It is
+    recoloured because white is a design choice and unfindable on the plot's
+    own white ground.
     """
 
     #: r1 searches the shelf for 10s, then walks 10s to the counter.
     PLAN = ("search r1 shelf mug", "move r1 shelf counter")
-    FPS, DURATION, T_END = 8, 2.0, 20.0
 
-    #: Frame 0 repeats the finished plan; 1-15 sample it evenly. The search
-    #: covers 1-8, but by 7 the ring has faded to nothing a codec can carry,
-    #: so the tail is left untested rather than pinned to a fading threshold.
-    SEARCHING = slice(1, 7)
+    #: Frame 0 repeats the finished plan; 1-16 sample it evenly, so the search
+    #: covers 1-8. It is not asserted over all of those: for 1-2 the ring is
+    #: still narrower than the robot it comes out of, and by 7 it has faded to
+    #: less than a codec will carry.
+    SEARCHING = slice(3, 7)
     AFTERWARDS = slice(9, None)
 
     #: Chroma the ring has to beat. H.264 tints flat white by up to ~25.
     CHROMA = 40
 
     @pytest.fixture
-    def green_ring(self, monkeypatch):
-        from railroad.plotting import pulses
-
-        make_ring = pulses.make_ring
-
-        def coloured(*args, **kwargs):
-            ring = make_ring(*args, **kwargs)
-            ring.set_edgecolor("#00ff00")
-            return ring
-
-        monkeypatch.setattr(pulses, "make_ring", coloured)
-
-    @pytest.fixture
-    def dashboard(self):
+    def dashboard(self, monkeypatch):
         from railroad import operators
         from railroad._bindings import State
         from railroad.core import Fluent as F, get_action_by_name
         from railroad.dashboard import PlannerDashboard
         from railroad.environment import ObjectSearchEnvironment
-        from railroad.plotting.pulses import PULSE_RADIUS_M
+        from railroad.plotting import pulses
 
-        class Scene:
-            #: Metres per cell, sized so the full ring is 10 cells across this
-            #: 40x30 map -- clear of the frame, which would clip its growth.
-            resolution = PULSE_RADIUS_M / 10.0
+        make_ring = pulses.make_ring
+
+        def lime(*args, **kwargs):
+            ring = make_ring(*args, **kwargs)
+            ring.set_edgecolor("#00ff00")
+            return ring
+
+        monkeypatch.setattr(pulses, "make_ring", lime)
 
         class SearchEnvironment(ObjectSearchEnvironment):
             def define_operators(self):
                 return [
                     operators.construct_search_operator(1.0, 10.0),
-                    operators.construct_move_operator_blocking(
-                        lambda r, a, b: 10.0
-                    ),
+                    operators.construct_move_operator_blocking(lambda r, a, b: 10.0),
                 ]
 
         env = SearchEnvironment(
             state=State(0.0, {F("at r1 shelf"), F("free r1")}, []),
             objects_by_type={
-                "robot": {"r1"},
-                "location": {"shelf", "counter"},
+                "robot": {"r1"}, "location": {"shelf", "counter"},
                 "object": {"mug"},
             },
             true_object_locations={"shelf": set(), "counter": {"mug"}},
         )
-        env.occupancy_grid = np.zeros((40, 30))  # ty: ignore[unresolved-attribute]
-        env.scene = Scene()  # ty: ignore[unresolved-attribute]
-
         dashboard = PlannerDashboard(
             F("found mug"), env, force_interactive=False, print_on_exit=False,
         )
@@ -473,25 +460,9 @@ class TestSearchPulseSurvivesCompositing:
                 dashboard._do_update(env.state, last_action_name=name)
         return dashboard
 
-    @pytest.fixture
-    def spans(self, dashboard, tmp_path, green_ring):
-        """The ring's width in pixels for each frame, 0.0 where undrawn."""
-        import subprocess
-
-        out = tmp_path / "pulses.mp4"
-        dashboard.save_video(
-            str(out),
-            location_coords={"shelf": (10.0, 15.0), "counter": (32.0, 8.0)},
-            fps=self.FPS, duration=self.DURATION, figsize=(6.0, 4.0), dpi=100,
-        )
-        subprocess.run(
-            ["ffmpeg", "-v", "error", "-i", str(out), str(tmp_path / "f%02d.png")],
-            check=True, capture_output=True,
-        )
-        return [self._span(frame) for frame in sorted(tmp_path.glob("f*.png"))]
-
     @classmethod
     def _span(cls, path) -> float:
+        """The ring's width in pixels in one frame, 0.0 where it is undrawn."""
         from PIL import Image
 
         pixels = np.asarray(Image.open(path).convert("RGB")).astype(int)
@@ -502,12 +473,25 @@ class TestSearchPulseSurvivesCompositing:
         cols = np.nonzero(drawn)[1]
         return float(cols.max() - cols.min())
 
-    def test_the_ring_radiates_while_the_robot_searches(self, spans):
+    def test_the_ring_radiates_while_the_robot_searches_and_not_after(
+        self, dashboard, tmp_path,
+    ):
+        import subprocess
+
+        out = tmp_path / "pulses.mp4"
+        dashboard.save_video(
+            str(out),
+            location_coords={"shelf": (2.0, 8.0), "counter": (9.0, 2.0)},
+            fps=8, duration=2.0, figsize=(6.0, 4.0), dpi=100,
+        )
+        subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", str(out), str(tmp_path / "f%02d.png")],
+            check=True, capture_output=True,
+        )
+        spans = [self._span(frame) for frame in sorted(tmp_path.glob("f*.png"))]
+
         searching = spans[self.SEARCHING]
         assert all(searching), f"no ring drawn during the search: {spans}"
         assert searching == sorted(searching), f"the ring did not grow: {spans}"
-        assert searching[-1] > 3 * searching[0], f"it barely grew: {spans}"
-
-    def test_the_ring_is_absent_before_the_search_and_after_it(self, spans):
         assert not spans[0], f"the poster frame has no search running: {spans}"
         assert not any(spans[self.AFTERWARDS]), f"the ring outlived it: {spans}"

--- a/packages/railroad/tests/test_video_duration.py
+++ b/packages/railroad/tests/test_video_duration.py
@@ -1,0 +1,141 @@
+"""How long a video comes out: `--video-time` and what it resolves to."""
+
+import pytest
+
+from railroad.dashboard.plotting import (
+    DEFAULT_VIDEO_DURATION,
+    parse_video_time,
+    resolve_video_duration,
+)
+
+PLAN_TIME = 1500.0
+
+
+class TestResolveVideoDuration:
+    def test_nothing_asked_for_gives_the_default(self):
+        assert resolve_video_duration(None, PLAN_TIME) == DEFAULT_VIDEO_DURATION
+
+    @pytest.mark.parametrize(
+        "spec", [15, 15.0, "15", "15.0", " 15 ", "15s", "15S", "15.0s", " 15 s"],
+    )
+    def test_a_number_is_seconds_of_video(self, spec):
+        """With or without the unit: `15` and `15s` say the same thing."""
+        assert resolve_video_duration(spec, PLAN_TIME) == 15.0
+
+    def test_a_length_ignores_what_the_plan_cost(self):
+        assert resolve_video_duration(15, 3.0) == resolve_video_duration(15, 9e9)
+
+    @pytest.mark.parametrize("spec", ["100x", "100X", " 100x "])
+    def test_a_speed_divides_the_plan_by_it(self, spec):
+        """The worked example: 1500 of plan at 100x is 15 seconds of video."""
+        assert resolve_video_duration(spec, PLAN_TIME) == 15.0
+
+    def test_a_fractional_speed_runs_longer_than_the_plan(self):
+        assert resolve_video_duration("0.5x", 30.0) == 60.0
+
+    def test_doubling_the_speed_halves_the_video(self):
+        assert (
+            resolve_video_duration("200x", PLAN_TIME) * 2
+            == resolve_video_duration("100x", PLAN_TIME)
+        )
+
+    @pytest.mark.parametrize(
+        "spec",
+        ["banana", "", "x", "s", "1e", "10x5", "--", "5sx", "5xs", "inf", "nan"],
+    )
+    def test_unreadable_specs_are_rejected(self, spec):
+        with pytest.raises(ValueError, match="video time"):
+            resolve_video_duration(spec, PLAN_TIME)
+
+    def test_the_unit_does_not_turn_a_speed_into_a_length(self):
+        """`s` and `x` are the whole of the grammar; only the last one counts."""
+        assert resolve_video_duration("100x", PLAN_TIME) == 15.0
+        assert resolve_video_duration("100s", PLAN_TIME) == 100.0
+
+    def test_a_space_before_the_x_is_tolerated(self):
+        """`float` ignores it, and nothing else could have been meant."""
+        assert resolve_video_duration("100 x", PLAN_TIME) == 15.0
+
+    @pytest.mark.parametrize("spec", ["0", "-5", "0s", "-5s", 0, -1.5])
+    def test_a_length_of_no_seconds_is_rejected(self, spec):
+        with pytest.raises(ValueError, match="length must be positive"):
+            resolve_video_duration(spec, PLAN_TIME)
+
+    @pytest.mark.parametrize("spec", ["0x", "-2x"])
+    def test_a_speed_of_zero_or_less_is_rejected(self, spec):
+        with pytest.raises(ValueError, match="speed must be positive"):
+            resolve_video_duration(spec, PLAN_TIME)
+
+    def test_a_speed_over_a_plan_that_cost_nothing_is_rejected(self):
+        """Only reachable here: the spec itself is fine, the plan is not."""
+        parse_video_time("100x")  # so the spec is not what is being rejected
+        with pytest.raises(ValueError, match="nothing to play"):
+            resolve_video_duration("100x", 0.0)
+
+
+class TestShowPlotsForwardsIt:
+    def test_video_time_reaches_save_video_unresolved(self, fetch_dashboard):
+        """Unresolved, because only save_video knows what the plan cost."""
+        seen = {}
+
+        def record(path, **kwargs):
+            seen.update(path=path, **kwargs)
+
+        fetch_dashboard.save_video = record
+        fetch_dashboard.show_plots(save_video="out.mp4", video_time="100x")
+        assert seen["duration"] == "100x"
+
+    def test_asking_for_no_video_time_leaves_the_default(self, fetch_dashboard):
+        seen = {}
+        fetch_dashboard.save_video = lambda path, **kwargs: seen.update(kwargs)
+        fetch_dashboard.show_plots(save_video="out.mp4")
+        assert seen["duration"] is None
+
+
+def _have_ffmpeg() -> bool:
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    from matplotlib.animation import FFMpegWriter
+
+    return FFMpegWriter.isAvailable()
+
+
+@pytest.mark.skipif(not _have_ffmpeg(), reason="ffmpeg not installed")
+class TestVideoIsAsLongAsAsked:
+    FPS = 5
+
+    def _frames(self, dashboard, path, duration, location_coords) -> int:
+        import subprocess
+
+        dashboard.save_video(
+            str(path), location_coords=location_coords, duration=duration,
+            fps=self.FPS, figsize=(4.0, 3.0), dpi=50,
+        )
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-count_frames",
+             "-show_entries", "stream=nb_read_frames", "-of", "csv=p=0", str(path)],
+            capture_output=True, text=True, check=True,
+        )
+        return int(probe.stdout.strip().rstrip(","))
+
+    def test_seconds_give_that_many_seconds_of_frames(
+        self, fetch_dashboard, tmp_path, location_coords,
+    ):
+        frames = self._frames(
+            fetch_dashboard, tmp_path / "secs.mp4", 2.0, location_coords,
+        )
+        # fps * duration, plus the leading poster frame
+        assert frames == self.FPS * 2 + 1
+
+    def test_twice_the_speed_writes_half_the_video(
+        self, fetch_dashboard, tmp_path, location_coords,
+    ):
+        """Asserted as a ratio: the plan's own cost is not a public number."""
+        slow = self._frames(
+            fetch_dashboard, tmp_path / "slow.mp4", "4x", location_coords,
+        )
+        fast = self._frames(
+            fetch_dashboard, tmp_path / "fast.mp4", "8x", location_coords,
+        )
+        assert slow > 3, "too few frames for the ratio to mean anything"
+        assert (slow - 1) == pytest.approx(2 * (fast - 1), abs=1)

--- a/packages/railroad/tests/test_video_duration.py
+++ b/packages/railroad/tests/test_video_duration.py
@@ -2,94 +2,46 @@
 
 import pytest
 
-from railroad.dashboard.plotting import (
-    DEFAULT_VIDEO_DURATION,
-    parse_video_time,
-    resolve_video_duration,
-)
+from railroad.dashboard.plotting import DEFAULT_VIDEO_DURATION, resolve_video_duration
 
 PLAN_TIME = 1500.0
 
 
-class TestResolveVideoDuration:
-    def test_nothing_asked_for_gives_the_default(self):
-        assert resolve_video_duration(None, PLAN_TIME) == DEFAULT_VIDEO_DURATION
-
-    @pytest.mark.parametrize(
-        "spec", [15, 15.0, "15", "15.0", " 15 ", "15s", "15S", "15.0s", " 15 s"],
-    )
-    def test_a_number_is_seconds_of_video(self, spec):
-        """With or without the unit: `15` and `15s` say the same thing."""
-        assert resolve_video_duration(spec, PLAN_TIME) == 15.0
-
-    def test_a_length_ignores_what_the_plan_cost(self):
-        assert resolve_video_duration(15, 3.0) == resolve_video_duration(15, 9e9)
-
-    @pytest.mark.parametrize("spec", ["100x", "100X", " 100x "])
-    def test_a_speed_divides_the_plan_by_it(self, spec):
-        """The worked example: 1500 of plan at 100x is 15 seconds of video."""
-        assert resolve_video_duration(spec, PLAN_TIME) == 15.0
-
-    def test_a_fractional_speed_runs_longer_than_the_plan(self):
-        assert resolve_video_duration("0.5x", 30.0) == 60.0
-
-    def test_doubling_the_speed_halves_the_video(self):
-        assert (
-            resolve_video_duration("200x", PLAN_TIME) * 2
-            == resolve_video_duration("100x", PLAN_TIME)
-        )
-
-    @pytest.mark.parametrize(
-        "spec",
-        ["banana", "", "x", "s", "1e", "10x5", "--", "5sx", "5xs", "inf", "nan"],
-    )
-    def test_unreadable_specs_are_rejected(self, spec):
-        with pytest.raises(ValueError, match="video time"):
-            resolve_video_duration(spec, PLAN_TIME)
-
-    def test_the_unit_does_not_turn_a_speed_into_a_length(self):
-        """`s` and `x` are the whole of the grammar; only the last one counts."""
-        assert resolve_video_duration("100x", PLAN_TIME) == 15.0
-        assert resolve_video_duration("100s", PLAN_TIME) == 100.0
-
-    def test_a_space_before_the_x_is_tolerated(self):
-        """`float` ignores it, and nothing else could have been meant."""
-        assert resolve_video_duration("100 x", PLAN_TIME) == 15.0
-
-    @pytest.mark.parametrize("spec", ["0", "-5", "0s", "-5s", 0, -1.5])
-    def test_a_length_of_no_seconds_is_rejected(self, spec):
-        with pytest.raises(ValueError, match="length must be positive"):
-            resolve_video_duration(spec, PLAN_TIME)
-
-    @pytest.mark.parametrize("spec", ["0x", "-2x"])
-    def test_a_speed_of_zero_or_less_is_rejected(self, spec):
-        with pytest.raises(ValueError, match="speed must be positive"):
-            resolve_video_duration(spec, PLAN_TIME)
-
-    def test_a_speed_over_a_plan_that_cost_nothing_is_rejected(self):
-        """Only reachable here: the spec itself is fine, the plan is not."""
-        parse_video_time("100x")  # so the spec is not what is being rejected
-        with pytest.raises(ValueError, match="nothing to play"):
-            resolve_video_duration("100x", 0.0)
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        (None, DEFAULT_VIDEO_DURATION),
+        (15, 15.0), ("15", 15.0), ("15s", 15.0), ("15S", 15.0),
+        ("100x", 15.0), ("100X", 15.0), ("0.5x", 3000.0),
+    ],
+)
+def test_a_video_time_is_seconds_unless_it_ends_in_x(spec, expected):
+    """`15` and `15s` both ask for fifteen seconds; `100x` plays 1500 in 15."""
+    assert resolve_video_duration(spec, PLAN_TIME) == expected
 
 
-class TestShowPlotsForwardsIt:
-    def test_video_time_reaches_save_video_unresolved(self, fetch_dashboard):
-        """Unresolved, because only save_video knows what the plan cost."""
-        seen = {}
+@pytest.mark.parametrize(
+    "spec, plan, complaint",
+    [
+        ("banana", PLAN_TIME, "video time"),  # not a number at all
+        ("", PLAN_TIME, "video time"),
+        ("inf", PLAN_TIME, "video time"),  # a number, but not a length
+        ("0", PLAN_TIME, "length must be positive"),
+        ("-2x", PLAN_TIME, "speed must be positive"),
+        ("100x", 0.0, "nothing to play"),  # the spec is fine, the plan is empty
+    ],
+)
+def test_what_is_not_a_video_length_is_rejected(spec, plan, complaint):
+    with pytest.raises(ValueError, match=complaint):
+        resolve_video_duration(spec, plan)
 
-        def record(path, **kwargs):
-            seen.update(path=path, **kwargs)
 
-        fetch_dashboard.save_video = record
-        fetch_dashboard.show_plots(save_video="out.mp4", video_time="100x")
-        assert seen["duration"] == "100x"
-
-    def test_asking_for_no_video_time_leaves_the_default(self, fetch_dashboard):
-        seen = {}
-        fetch_dashboard.save_video = lambda path, **kwargs: seen.update(kwargs)
-        fetch_dashboard.show_plots(save_video="out.mp4")
-        assert seen["duration"] is None
+def test_video_time_reaches_save_video_unresolved(fetch_dashboard):
+    """Unresolved, because only `save_video` knows what the plan cost."""
+    seen = {}
+    fetch_dashboard.save_video = lambda path, **kwargs: seen.update(kwargs)
+    fetch_dashboard.show_plots(save_video="out.mp4", video_time="100x")
+    assert seen["duration"] == "100x"
 
 
 def _have_ffmpeg() -> bool:
@@ -101,41 +53,22 @@ def _have_ffmpeg() -> bool:
 
 
 @pytest.mark.skipif(not _have_ffmpeg(), reason="ffmpeg not installed")
-class TestVideoIsAsLongAsAsked:
-    FPS = 5
+def test_the_video_is_as_long_as_it_was_asked_to_be(
+    fetch_dashboard, tmp_path, location_coords,
+):
+    """That a resolved duration is what actually reaches the writer."""
+    import subprocess
 
-    def _frames(self, dashboard, path, duration, location_coords) -> int:
-        import subprocess
-
-        dashboard.save_video(
-            str(path), location_coords=location_coords, duration=duration,
-            fps=self.FPS, figsize=(4.0, 3.0), dpi=50,
-        )
-        probe = subprocess.run(
-            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-count_frames",
-             "-show_entries", "stream=nb_read_frames", "-of", "csv=p=0", str(path)],
-            capture_output=True, text=True, check=True,
-        )
-        return int(probe.stdout.strip().rstrip(","))
-
-    def test_seconds_give_that_many_seconds_of_frames(
-        self, fetch_dashboard, tmp_path, location_coords,
-    ):
-        frames = self._frames(
-            fetch_dashboard, tmp_path / "secs.mp4", 2.0, location_coords,
-        )
-        # fps * duration, plus the leading poster frame
-        assert frames == self.FPS * 2 + 1
-
-    def test_twice_the_speed_writes_half_the_video(
-        self, fetch_dashboard, tmp_path, location_coords,
-    ):
-        """Asserted as a ratio: the plan's own cost is not a public number."""
-        slow = self._frames(
-            fetch_dashboard, tmp_path / "slow.mp4", "4x", location_coords,
-        )
-        fast = self._frames(
-            fetch_dashboard, tmp_path / "fast.mp4", "8x", location_coords,
-        )
-        assert slow > 3, "too few frames for the ratio to mean anything"
-        assert (slow - 1) == pytest.approx(2 * (fast - 1), abs=1)
+    fps, duration = 5, 2
+    out = tmp_path / "secs.mp4"
+    fetch_dashboard.save_video(
+        str(out), location_coords=location_coords, duration=float(duration),
+        fps=fps, figsize=(4.0, 3.0), dpi=50,
+    )
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0", "-count_frames",
+         "-show_entries", "stream=nb_read_frames", "-of", "csv=p=0", str(out)],
+        capture_output=True, text=True, check=True,
+    )
+    # fps * duration, plus the leading poster frame
+    assert int(probe.stdout.strip().rstrip(",")) == fps * duration + 1


### PR DESCRIPTION
## Summary

- A robot searching a location now radiates a white ring out of itself, growing to 1m and fading as the search runs, so a stationary robot reads as sensing rather than waiting. Video only — the static plot has no instant at which a search is running.
- `--video-time` sets how long the video runs: `15` or `15s` for a fixed length, `100x` for a *speed* (a plan costing 1500 comes out 15 seconds). Default is still 10s. Ten seconds as the only option flattened every plan to the same runtime, and the difference between a 20-second errand and a 20-minute search is most of what the video is for.
- The length and frame count are announced before the first frame — `Writing 19.0s of video at 60 fps — 1140 frames, 5x plan speed. Ctrl-C keeps what is written.` A speed over a long plan can quietly run to thousands of frames, which the flag that asked for it does not show.

## Notes for review

- **Search windows come out of the fluent snapshots the dashboard already keeps**, so there is no new capture hook. A dispatch takes the robot's `free` away and the completion gives it back, so a window ends at the next snapshot in which the robot is free again. That is exact rather than approximate: `act()` returns whenever *a* robot frees, so the completion is always a snapshot, and nothing can free the robot earlier because it is busy. Keying on `free` rather than `searched` also covers `search-frontier`.
- **The radius goes through the scene resolution**, since a metre means nothing in the grid cells the plot is drawn in. A symbolic domain that reports no resolution falls back to the sprite fan's screen-derived length.
- **A speed cannot be resolved until the plan has a cost**, so `save_video` resolves the spec once it knows `t_end`. The syntax is checkable immediately though, so `parse_video_time` is split out for a click callback — `--video-time bananas` fails before planning rather than after it.
- `--video-time` is threaded through all eight example `main()` signatures because the CLI passes the global video options as explicit kwargs. That is why the diff touches so many files for so little.

## Testing

- `uv run pytest` — 789 passed, 1 skipped, 1 xfailed. `ty` and `ruff` clean on the touched files.
- 26 new tests: 9 for the window derivation and ring geometry, 16 for the `--video-time` grammar and its wiring, and 1 driving a real search through the video compositing loop. Deliberately tight for the size of the feature — checked by mutating the source eleven ways (closing a window on its own dispatch snapshot, letting any robot's `free` end a search, dropping the fade, multiplying instead of dividing by a speed, …) and confirming each is caught.
- By eye on `railroad example procthor-search`: two robots searching concurrently each carry their own ring, and `--video-time 5x` turned a 95.0s plan into exactly 19.000000s by `ffprobe`.
